### PR TITLE
Feat: 운영진 리스트 조회 API 구현

### DIFF
--- a/src/main/java/com/umc/site/domain/club_admin/controller/ClubAdminController.java
+++ b/src/main/java/com/umc/site/domain/club_admin/controller/ClubAdminController.java
@@ -1,0 +1,27 @@
+package com.umc.site.domain.club_admin.controller;
+
+import com.umc.site.domain.club_admin.dto.ClubAdminResponseDTO;
+import com.umc.site.domain.club_admin.service.ClubAdminQueryService;
+import com.umc.site.global.apiPayload.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+public class ClubAdminController {
+
+    private final ClubAdminQueryService clubAdminQueryService;
+
+    @Operation(summary = "운영진 리스트 조회", description = "운영진 리스트를 불러옵니다.")
+    @GetMapping("/club-admins")
+    public ApiResponse<List<ClubAdminResponseDTO.ClubAdminInfoDTO>> getClubAdmins() {
+
+        return ApiResponse.onSuccess(clubAdminQueryService.getClubAdminList());
+    }
+}

--- a/src/main/java/com/umc/site/domain/club_admin/converter/ClubAdminConverter.java
+++ b/src/main/java/com/umc/site/domain/club_admin/converter/ClubAdminConverter.java
@@ -1,0 +1,28 @@
+package com.umc.site.domain.club_admin.converter;
+
+import com.umc.site.domain.club_admin.dto.ClubAdminResponseDTO;
+import com.umc.site.domain.club_admin.entity.ClubAdmin;
+import com.umc.site.domain.image.converter.ImageConverter;
+import com.umc.site.domain.image.entity.Image;
+import com.umc.site.domain.role_history.converter.RoleHistoryConverter;
+import com.umc.site.domain.role_history.entity.RoleHistory;
+
+import java.util.List;
+
+public class ClubAdminConverter {
+
+    public static ClubAdminResponseDTO.ClubAdminInfoDTO toClubAdminInfoDTO(ClubAdmin clubAdmin, Image image, List<RoleHistory> roleHistories) {
+
+        return ClubAdminResponseDTO.ClubAdminInfoDTO.builder()
+                .clubAdminId(clubAdmin.getId())
+                .name(clubAdmin.getName())
+                .nickname(clubAdmin.getNickname())
+                .commitment(clubAdmin.getCommitment())
+                .role(clubAdmin.getRole())
+                .image(ImageConverter.toImageDTO(image))
+                .roleHistories(roleHistories.stream()
+                        .map(RoleHistoryConverter::toRoleHistoryDTO)
+                        .toList())
+                .build();
+    }
+}

--- a/src/main/java/com/umc/site/domain/club_admin/dto/ClubAdminResponseDTO.java
+++ b/src/main/java/com/umc/site/domain/club_admin/dto/ClubAdminResponseDTO.java
@@ -1,0 +1,28 @@
+package com.umc.site.domain.club_admin.dto;
+
+import com.umc.site.domain.club_admin.enums.Role;
+import com.umc.site.domain.image.dto.ImageResponseDTO;
+import com.umc.site.domain.role_history.dto.RoleHistoryResponseDTO;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+public class ClubAdminResponseDTO {
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ClubAdminInfoDTO {
+        Long clubAdminId;
+        String name;
+        String nickname;
+        String commitment;
+        Role role;
+        ImageResponseDTO.ImageDTO image;
+        List<RoleHistoryResponseDTO.RoleHistoryDTO> roleHistories;
+    }
+}

--- a/src/main/java/com/umc/site/domain/club_admin/entity/ClubAdmin.java
+++ b/src/main/java/com/umc/site/domain/club_admin/entity/ClubAdmin.java
@@ -1,0 +1,38 @@
+package com.umc.site.domain.club_admin.entity;
+
+import com.umc.site.domain.club_admin.enums.Role;
+import com.umc.site.domain.role_history.entity.RoleHistory;
+import com.umc.site.global.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Builder
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class ClubAdmin extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 10)
+    private String name;
+
+    @Column(nullable = false, length = 10)
+    private String nickname;
+
+    @Column(nullable = false, length = 50)
+    private String commitment;
+
+    @Enumerated(EnumType.STRING)
+    @Column(columnDefinition = "VARCHAR(30)")
+    private Role role;
+
+    @OneToMany(cascade = CascadeType.ALL, mappedBy = "clubAdmin")
+    private List<RoleHistory> roleHistories = new ArrayList<>();
+}

--- a/src/main/java/com/umc/site/domain/club_admin/enums/Role.java
+++ b/src/main/java/com/umc/site/domain/club_admin/enums/Role.java
@@ -4,11 +4,11 @@ public enum Role {
 
     PRESIDENT,           // 회장
     VICE_PRESIDENT,      // 부회장
-    SPRING_BOOT_LEAD,    // SpringBoot 파트장
-    ANDROID_LEAD,        // Android 파트장
-    WEB_LEAD,            // Web 파트장
-    DESIGN_LEAD,         // Design 파트장
-    PLAN_LEAD,       // Plan 파트장
-    NODEJS_LEAD,         // Node.js 파트장
-    IOS_LEAD             // IOS 파트장
+    SPRING_BOOT_LEADER,    // SpringBoot 파트장
+    ANDROID_LEADER,        // Android 파트장
+    WEB_LEADER,            // Web 파트장
+    DESIGN_LEADER,         // Design 파트장
+    PLAN_LEADER,       // Plan 파트장
+    NODEJS_LEADER,         // Node.js 파트장
+    IOS_LEADER             // IOS 파트장
 }

--- a/src/main/java/com/umc/site/domain/club_admin/enums/Role.java
+++ b/src/main/java/com/umc/site/domain/club_admin/enums/Role.java
@@ -1,0 +1,14 @@
+package com.umc.site.domain.club_admin.enums;
+
+public enum Role {
+
+    PRESIDENT,           // 회장
+    VICE_PRESIDENT,      // 부회장
+    SPRING_BOOT_LEAD,    // SpringBoot 파트장
+    ANDROID_LEAD,        // Android 파트장
+    WEB_LEAD,            // Web 파트장
+    DESIGN_LEAD,         // Design 파트장
+    PLAN_LEAD,       // Plan 파트장
+    NODEJS_LEAD,         // Node.js 파트장
+    IOS_LEAD             // IOS 파트장
+}

--- a/src/main/java/com/umc/site/domain/club_admin/enums/Role.java
+++ b/src/main/java/com/umc/site/domain/club_admin/enums/Role.java
@@ -10,5 +10,7 @@ public enum Role {
     DESIGN_LEADER,         // Design 파트장
     PLAN_LEADER,       // Plan 파트장
     NODEJS_LEADER,         // Node.js 파트장
-    IOS_LEADER             // IOS 파트장
+    IOS_LEADER,             // IOS 파트장
+
+    MANAGE_LEADER          // 운영팀장
 }

--- a/src/main/java/com/umc/site/domain/club_admin/repository/ClubAdminRepository.java
+++ b/src/main/java/com/umc/site/domain/club_admin/repository/ClubAdminRepository.java
@@ -1,0 +1,7 @@
+package com.umc.site.domain.club_admin.repository;
+
+import com.umc.site.domain.club_admin.entity.ClubAdmin;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ClubAdminRepository extends JpaRepository<ClubAdmin, Long> {
+}

--- a/src/main/java/com/umc/site/domain/club_admin/service/ClubAdminQueryService.java
+++ b/src/main/java/com/umc/site/domain/club_admin/service/ClubAdminQueryService.java
@@ -1,0 +1,11 @@
+package com.umc.site.domain.club_admin.service;
+
+import com.umc.site.domain.club_admin.dto.ClubAdminResponseDTO;
+
+import java.util.List;
+
+public interface ClubAdminQueryService {
+
+    List<ClubAdminResponseDTO.ClubAdminInfoDTO> getClubAdminList();
+
+}

--- a/src/main/java/com/umc/site/domain/club_admin/service/ClubAdminQueryServiceImpl.java
+++ b/src/main/java/com/umc/site/domain/club_admin/service/ClubAdminQueryServiceImpl.java
@@ -1,0 +1,42 @@
+package com.umc.site.domain.club_admin.service;
+
+import com.umc.site.domain.club_admin.converter.ClubAdminConverter;
+import com.umc.site.domain.club_admin.dto.ClubAdminResponseDTO;
+import com.umc.site.domain.club_admin.entity.ClubAdmin;
+import com.umc.site.domain.club_admin.repository.ClubAdminRepository;
+import com.umc.site.domain.image.entity.Image;
+import com.umc.site.domain.image.repository.ImageRepository;
+import com.umc.site.domain.role_history.entity.RoleHistory;
+import com.umc.site.domain.role_history.repository.RoleHistoryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ClubAdminQueryServiceImpl implements ClubAdminQueryService{
+
+    private final ClubAdminRepository clubAdminRepository;
+    private final ImageRepository imageRepository;
+    private final RoleHistoryRepository roleHistoryRepository;
+
+    @Override
+    public List<ClubAdminResponseDTO.ClubAdminInfoDTO> getClubAdminList() {
+
+        List<ClubAdmin> clubAdmins = clubAdminRepository.findAll();
+
+        return clubAdmins.stream()
+                .map(clubAdmin -> {
+                    Image image = imageRepository.findByClubAdmin(clubAdmin);
+                    List<RoleHistory> roleHistories = roleHistoryRepository.findAllByClubAdmin(clubAdmin);
+
+                    return ClubAdminConverter.toClubAdminInfoDTO(clubAdmin, image, roleHistories);
+                })
+                .collect(Collectors.toList());
+    }
+
+}

--- a/src/main/java/com/umc/site/domain/image/converter/ImageConverter.java
+++ b/src/main/java/com/umc/site/domain/image/converter/ImageConverter.java
@@ -1,0 +1,16 @@
+package com.umc.site.domain.image.converter;
+
+import com.umc.site.domain.image.dto.ImageResponseDTO;
+import com.umc.site.domain.image.entity.Image;
+
+public class ImageConverter {
+
+    public static ImageResponseDTO.ImageDTO toImageDTO(Image image) {
+
+        return ImageResponseDTO.ImageDTO.builder()
+                .uuid(image.getUuid())
+                .fileUrl(image.getFileUrl())
+                .fileName(image.getFileName())
+                .build();
+    }
+}

--- a/src/main/java/com/umc/site/domain/image/dto/ImageResponseDTO.java
+++ b/src/main/java/com/umc/site/domain/image/dto/ImageResponseDTO.java
@@ -1,0 +1,19 @@
+package com.umc.site.domain.image.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class ImageResponseDTO {
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ImageDTO {
+        String uuid;
+        String fileName;
+        String fileUrl;
+    }
+}

--- a/src/main/java/com/umc/site/domain/image/entity/Image.java
+++ b/src/main/java/com/umc/site/domain/image/entity/Image.java
@@ -1,0 +1,37 @@
+package com.umc.site.domain.image.entity;
+
+import com.umc.site.domain.club_admin.entity.ClubAdmin;
+import com.umc.site.domain.image.enums.ImageableType;
+import com.umc.site.global.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Image extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 100, unique = true)
+    private String uuid;
+
+    @Column(nullable = false, length = 100)
+    private String fileName;
+
+    @Column(nullable = false, length = 300)
+    private String fileUrl;
+
+    @Enumerated(EnumType.STRING)
+    @Column(columnDefinition = "VARCHAR(20)")
+    private ImageableType imageableType;
+
+
+    @OneToOne(cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    @JoinColumn(name = "club_admin_id", referencedColumnName = "id")
+    private ClubAdmin clubAdmin;
+}

--- a/src/main/java/com/umc/site/domain/image/enums/ImageableType.java
+++ b/src/main/java/com/umc/site/domain/image/enums/ImageableType.java
@@ -1,6 +1,0 @@
-package com.umc.site.domain.image.enums;
-
-public enum ImageableType {
-    CLUB_ADMIN,
-    PROJECT
-}

--- a/src/main/java/com/umc/site/domain/image/enums/ImageableType.java
+++ b/src/main/java/com/umc/site/domain/image/enums/ImageableType.java
@@ -1,0 +1,6 @@
+package com.umc.site.domain.image.enums;
+
+public enum ImageableType {
+    CLUB_ADMIN,
+    PROJECT
+}

--- a/src/main/java/com/umc/site/domain/image/repository/ImageRepository.java
+++ b/src/main/java/com/umc/site/domain/image/repository/ImageRepository.java
@@ -1,0 +1,11 @@
+package com.umc.site.domain.image.repository;
+
+import com.umc.site.domain.club_admin.entity.ClubAdmin;
+import com.umc.site.domain.image.entity.Image;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ImageRepository extends JpaRepository<Image, Long> {
+
+    Image findByClubAdmin(ClubAdmin clubAdmin);
+
+}

--- a/src/main/java/com/umc/site/domain/role_history/converter/RoleHistoryConverter.java
+++ b/src/main/java/com/umc/site/domain/role_history/converter/RoleHistoryConverter.java
@@ -1,0 +1,17 @@
+package com.umc.site.domain.role_history.converter;
+
+import com.umc.site.domain.role_history.dto.RoleHistoryResponseDTO;
+import com.umc.site.domain.role_history.entity.RoleHistory;
+
+public class RoleHistoryConverter {
+
+    public static RoleHistoryResponseDTO.RoleHistoryDTO toRoleHistoryDTO(RoleHistory roleHistory) {
+
+        return RoleHistoryResponseDTO.RoleHistoryDTO.builder()
+                .id(roleHistory.getId())
+                .content(roleHistory.getContent())
+                .build();
+    }
+
+
+}

--- a/src/main/java/com/umc/site/domain/role_history/dto/RoleHistoryResponseDTO.java
+++ b/src/main/java/com/umc/site/domain/role_history/dto/RoleHistoryResponseDTO.java
@@ -1,0 +1,18 @@
+package com.umc.site.domain.role_history.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class RoleHistoryResponseDTO {
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class RoleHistoryDTO {
+        Long id;
+        String content;
+    }
+}

--- a/src/main/java/com/umc/site/domain/role_history/entity/RoleHistory.java
+++ b/src/main/java/com/umc/site/domain/role_history/entity/RoleHistory.java
@@ -1,0 +1,25 @@
+package com.umc.site.domain.role_history.entity;
+
+import com.umc.site.domain.club_admin.entity.ClubAdmin;
+import com.umc.site.global.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Builder
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class RoleHistory extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 20)
+    private String content;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "club_admin_id")
+    private ClubAdmin clubAdmin;
+}

--- a/src/main/java/com/umc/site/domain/role_history/repository/RoleHistoryRepository.java
+++ b/src/main/java/com/umc/site/domain/role_history/repository/RoleHistoryRepository.java
@@ -1,0 +1,11 @@
+package com.umc.site.domain.role_history.repository;
+
+import com.umc.site.domain.club_admin.entity.ClubAdmin;
+import com.umc.site.domain.role_history.entity.RoleHistory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface RoleHistoryRepository extends JpaRepository<RoleHistory, Long> {
+    List<RoleHistory> findAllByClubAdmin(ClubAdmin clubAdmin);
+}

--- a/src/main/java/com/umc/site/global/config/SwaggerConfig.java
+++ b/src/main/java/com/umc/site/global/config/SwaggerConfig.java
@@ -12,7 +12,7 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 public class SwaggerConfig {
     @Bean
-    public OpenAPI UMCstudyAPI() {
+    public OpenAPI UMCSiteAPI() {
         Info info = new Info()
                 .title("UMC Recruiting Site API")
                 .description("UMC Recruiting Site API 명세서")


### PR DESCRIPTION
## 🛰️ Issue Number
- resolve #1 

## 📝 작업 내용
-   엔티티를 추가했습니다.
-  각 엔티티에 맞는 DTO와 Converter를 구현했습니다.
-  각 엔티티의 Repository를 구현했습니다.
- Service에서 DTO를 반환하도록 구현했습니다.

## 💬 리뷰 요구사항
> 우선 Image 엔티티에 Enum을 추가하긴 했는데, 만약 FK로 운영진과 프로젝트 id를 참조한다면 Enum이 필요할지 궁금합니다!
