### PR TITLE
FEAT: 기수별 프로젝트 목록 조회 API 구현 #2

### DIFF
--- a/src/main/java/com/umc/site/domain/club_admin/enums/ServiceType.java
+++ b/src/main/java/com/umc/site/domain/club_admin/enums/ServiceType.java
@@ -1,0 +1,7 @@
+package com.umc.site.domain.club_admin.enums;
+
+public enum ServiceType {
+    WEB,
+    ANDROID,
+    IOS
+}

--- a/src/main/java/com/umc/site/domain/cohort/entity/Cohort.java
+++ b/src/main/java/com/umc/site/domain/cohort/entity/Cohort.java
@@ -1,0 +1,28 @@
+package com.umc.site.domain.cohort.entity;
+
+import com.umc.site.domain.project.entity.Project;
+import com.umc.site.global.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Builder
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Cohort extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // 기수명 (ex. 7기)
+    @Column(nullable = false, length = 20)
+    private String name;
+
+    @OneToMany(cascade = CascadeType.ALL, mappedBy = "cohort")
+    private List<Project> projects = new ArrayList<>();
+}

--- a/src/main/java/com/umc/site/domain/cohort/repository/CohortRepository.java
+++ b/src/main/java/com/umc/site/domain/cohort/repository/CohortRepository.java
@@ -1,0 +1,7 @@
+package com.umc.site.domain.cohort.repository;
+
+import com.umc.site.domain.cohort.entity.Cohort;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CohortRepository extends JpaRepository<Cohort, Long> {
+}

--- a/src/main/java/com/umc/site/domain/feature/entity/Feature.java
+++ b/src/main/java/com/umc/site/domain/feature/entity/Feature.java
@@ -1,0 +1,27 @@
+package com.umc.site.domain.feature.entity;
+
+import com.umc.site.domain.project.entity.Project;
+import com.umc.site.global.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Builder
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Feature extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // 내용
+    @Column(nullable = false, length = 200)
+    private String content;
+
+    // 프로젝트 (fk)
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "project_id")
+    private Project project;
+}

--- a/src/main/java/com/umc/site/domain/feature/repository/FeatureRepository.java
+++ b/src/main/java/com/umc/site/domain/feature/repository/FeatureRepository.java
@@ -1,0 +1,7 @@
+package com.umc.site.domain.feature.repository;
+
+import com.umc.site.domain.feature.entity.Feature;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FeatureRepository extends JpaRepository<Feature, Long> {
+}

--- a/src/main/java/com/umc/site/domain/image/entity/Image.java
+++ b/src/main/java/com/umc/site/domain/image/entity/Image.java
@@ -1,7 +1,7 @@
 package com.umc.site.domain.image.entity;
 
 import com.umc.site.domain.club_admin.entity.ClubAdmin;
-import com.umc.site.domain.image.enums.ImageableType;
+import com.umc.site.domain.project.entity.Project;
 import com.umc.site.global.common.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
@@ -26,12 +26,11 @@ public class Image extends BaseEntity {
     @Column(nullable = false, length = 300)
     private String fileUrl;
 
-    @Enumerated(EnumType.STRING)
-    @Column(columnDefinition = "VARCHAR(20)")
-    private ImageableType imageableType;
-
-
     @OneToOne(cascade = CascadeType.ALL, fetch = FetchType.LAZY)
     @JoinColumn(name = "club_admin_id", referencedColumnName = "id")
     private ClubAdmin clubAdmin;
+
+    @OneToOne(cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    @JoinColumn(name = "project_id", referencedColumnName = "id")
+    private Project project;
 }

--- a/src/main/java/com/umc/site/domain/image/repository/ImageRepository.java
+++ b/src/main/java/com/umc/site/domain/image/repository/ImageRepository.java
@@ -2,10 +2,13 @@ package com.umc.site.domain.image.repository;
 
 import com.umc.site.domain.club_admin.entity.ClubAdmin;
 import com.umc.site.domain.image.entity.Image;
+import com.umc.site.domain.project.entity.Project;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ImageRepository extends JpaRepository<Image, Long> {
 
     Image findByClubAdmin(ClubAdmin clubAdmin);
+
+    Image findByProject(Project project);
 
 }

--- a/src/main/java/com/umc/site/domain/project/controller/ProjectController.java
+++ b/src/main/java/com/umc/site/domain/project/controller/ProjectController.java
@@ -7,10 +7,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -22,11 +19,11 @@ public class ProjectController {
 
     // 기수별 프로젝트 목록 조회
     @Operation(summary = "기수별 프로젝트 목록 조회", description = " 기수별 프로젝트 리스트를 불러옵니다.")
-    @GetMapping("/projects/{cohortId}")
+    @GetMapping("/projects")
     @Parameters({
-            @Parameter(name = "cohortId", description = "기수의 ID, path variable 입니다.")
+            @Parameter(name = "cohortId", description = "기수의 ID, query variable 입니다.")
     })
-    public ApiResponse<List<ProjectResponseDTO.ProjectPreviewDTO>> getProjectPreviews(@PathVariable(name = "cohortId") Long cohortId) {
+    public ApiResponse<List<ProjectResponseDTO.ProjectPreviewDTO>> getProjectPreviews(@RequestParam(name = "cohortId") Long cohortId) {
 
         return ApiResponse.onSuccess(projectQueryService.getProjectPreviewList(cohortId));
     }

--- a/src/main/java/com/umc/site/domain/project/controller/ProjectController.java
+++ b/src/main/java/com/umc/site/domain/project/controller/ProjectController.java
@@ -1,0 +1,33 @@
+package com.umc.site.domain.project.controller;
+
+import com.umc.site.domain.project.dto.ProjectResponseDTO;
+import com.umc.site.domain.project.service.ProjectQueryService;
+import com.umc.site.global.apiPayload.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+public class ProjectController {
+    private final ProjectQueryService projectQueryService;
+
+    // 기수별 프로젝트 목록 조회
+    @Operation(summary = "기수별 프로젝트 목록 조회", description = " 기수별 프로젝트 리스트를 불러옵니다.")
+    @GetMapping("/projects/{cohortId}")
+    @Parameters({
+            @Parameter(name = "cohortId", description = "기수의 ID, path variable 입니다.")
+    })
+    public ApiResponse<List<ProjectResponseDTO.ProjectPreviewDTO>> getProjectPreviews(@PathVariable(name = "cohortId") Long cohortId) {
+
+        return ApiResponse.onSuccess(projectQueryService.getProjectPreviewList(cohortId));
+    }
+}

--- a/src/main/java/com/umc/site/domain/project/converter/ProjectConverter.java
+++ b/src/main/java/com/umc/site/domain/project/converter/ProjectConverter.java
@@ -1,0 +1,23 @@
+package com.umc.site.domain.project.converter;
+
+import com.umc.site.domain.image.converter.ImageConverter;
+import com.umc.site.domain.image.entity.Image;
+import com.umc.site.domain.project.dto.ProjectResponseDTO;
+import com.umc.site.domain.project.entity.Project;
+
+public class ProjectConverter {
+
+    // 기수별 프로젝트 목록 조회
+    public static ProjectResponseDTO.ProjectPreviewDTO toProjectPreviewDTO(Project project, Image image) {
+
+        return ProjectResponseDTO.ProjectPreviewDTO.builder()
+                .projectId(project.getId())
+                .title(project.getTitle())
+                .pm(project.getPm())
+                .front_end(project.getFront_end())
+                .back_end(project.getBack_end())
+                .serviceType(project.getServiceType())
+                .image(ImageConverter.toImageDTO(image))
+                .build();
+    }
+}

--- a/src/main/java/com/umc/site/domain/project/converter/ProjectConverter.java
+++ b/src/main/java/com/umc/site/domain/project/converter/ProjectConverter.java
@@ -14,8 +14,8 @@ public class ProjectConverter {
                 .projectId(project.getId())
                 .title(project.getTitle())
                 .pm(project.getPm())
-                .front_end(project.getFront_end())
-                .back_end(project.getBack_end())
+                .frontEnd(project.getFrontEnd())
+                .backEnd(project.getBackEnd())
                 .serviceType(project.getServiceType())
                 .image(ImageConverter.toImageDTO(image))
                 .build();

--- a/src/main/java/com/umc/site/domain/project/dto/ProjectResponseDTO.java
+++ b/src/main/java/com/umc/site/domain/project/dto/ProjectResponseDTO.java
@@ -1,0 +1,27 @@
+package com.umc.site.domain.project.dto;
+
+import com.umc.site.domain.image.dto.ImageResponseDTO;
+import com.umc.site.domain.project.enums.ServiceType;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class ProjectResponseDTO {
+
+    // 기수별 프로젝트 목록 조회
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ProjectPreviewDTO {
+        private Long projectId;
+        private String title;
+        private String pm;
+        private String front_end;
+        private String back_end;
+        private String design;
+        private ServiceType serviceType;
+        private ImageResponseDTO.ImageDTO image;
+    }
+}

--- a/src/main/java/com/umc/site/domain/project/dto/ProjectResponseDTO.java
+++ b/src/main/java/com/umc/site/domain/project/dto/ProjectResponseDTO.java
@@ -18,8 +18,8 @@ public class ProjectResponseDTO {
         private Long projectId;
         private String title;
         private String pm;
-        private String front_end;
-        private String back_end;
+        private String frontEnd;
+        private String backEnd;
         private String design;
         private ServiceType serviceType;
         private ImageResponseDTO.ImageDTO image;

--- a/src/main/java/com/umc/site/domain/project/entity/Project.java
+++ b/src/main/java/com/umc/site/domain/project/entity/Project.java
@@ -31,11 +31,11 @@ public class Project extends BaseEntity {
 
     // 프론트엔드 사람들
     @Column(length = 100)
-    private String front_end;
+    private String frontEnd;
 
     // 백엔드 사람들
     @Column(length = 100)
-    private String back_end;
+    private String backEnd;
 
     // 디자인 사람들
     @Column(length = 100)

--- a/src/main/java/com/umc/site/domain/project/entity/Project.java
+++ b/src/main/java/com/umc/site/domain/project/entity/Project.java
@@ -1,0 +1,53 @@
+package com.umc.site.domain.project.entity;
+
+import com.umc.site.domain.club_admin.enums.ServiceType;
+import com.umc.site.domain.cohort.entity.Cohort;
+import com.umc.site.domain.feature.entity.Feature;
+import com.umc.site.global.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Builder
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Project extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // 프로젝트명
+    @Column(nullable = false, length = 20)
+    private String title;
+
+    // 프론트엔드 사람들
+    @Column(nullable = false, length = 100)
+    private String front_end;
+
+    // 백엔드 사람들
+    @Column(nullable = false, length = 100)
+    private String back_end;
+
+    // 서비스 유형
+    @Enumerated(EnumType.STRING)
+    @Column(columnDefinition = "VARCHAR(30)")
+    private ServiceType serviceType;
+
+    // 프로젝트 설명
+    @Column(nullable = false, length = 200)
+    private String description;
+
+    // 프로젝트 핵심 기능
+    @OneToMany(cascade = CascadeType.ALL, mappedBy = "project")
+    private List<Feature> features = new ArrayList<>();
+
+    // 기수 (fk)
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "cohort_id")
+    private Cohort cohort;
+}

--- a/src/main/java/com/umc/site/domain/project/entity/Project.java
+++ b/src/main/java/com/umc/site/domain/project/entity/Project.java
@@ -25,13 +25,21 @@ public class Project extends BaseEntity {
     @Column(nullable = false, length = 20)
     private String title;
 
+    // 기획 사람들
+    @Column(length = 100)
+    private String pm;
+
     // 프론트엔드 사람들
-    @Column(nullable = false, length = 100)
+    @Column(length = 100)
     private String front_end;
 
     // 백엔드 사람들
-    @Column(nullable = false, length = 100)
+    @Column(length = 100)
     private String back_end;
+
+    // 디자인 사람들
+    @Column(length = 100)
+    private String design;
 
     // 서비스 유형
     @Enumerated(EnumType.STRING)

--- a/src/main/java/com/umc/site/domain/project/entity/Project.java
+++ b/src/main/java/com/umc/site/domain/project/entity/Project.java
@@ -1,6 +1,6 @@
 package com.umc.site.domain.project.entity;
 
-import com.umc.site.domain.club_admin.enums.ServiceType;
+import com.umc.site.domain.project.enums.ServiceType;
 import com.umc.site.domain.cohort.entity.Cohort;
 import com.umc.site.domain.feature.entity.Feature;
 import com.umc.site.global.common.BaseEntity;

--- a/src/main/java/com/umc/site/domain/project/enums/ServiceType.java
+++ b/src/main/java/com/umc/site/domain/project/enums/ServiceType.java
@@ -1,4 +1,4 @@
-package com.umc.site.domain.club_admin.enums;
+package com.umc.site.domain.project.enums;
 
 public enum ServiceType {
     WEB,

--- a/src/main/java/com/umc/site/domain/project/repository/ProjectRepository.java
+++ b/src/main/java/com/umc/site/domain/project/repository/ProjectRepository.java
@@ -1,0 +1,7 @@
+package com.umc.site.domain.project.repository;
+
+import com.umc.site.domain.project.entity.Project;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProjectRepository  extends JpaRepository<Project, Long> {
+}

--- a/src/main/java/com/umc/site/domain/project/repository/ProjectRepository.java
+++ b/src/main/java/com/umc/site/domain/project/repository/ProjectRepository.java
@@ -3,5 +3,10 @@ package com.umc.site.domain.project.repository;
 import com.umc.site.domain.project.entity.Project;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface ProjectRepository  extends JpaRepository<Project, Long> {
+
+    // 기수별 프로젝트 목록 조회
+    List<Project> findAllByCohortId(Long cohortId);
 }

--- a/src/main/java/com/umc/site/domain/project/service/ProjectQueryService.java
+++ b/src/main/java/com/umc/site/domain/project/service/ProjectQueryService.java
@@ -1,0 +1,12 @@
+package com.umc.site.domain.project.service;
+
+import com.umc.site.domain.project.dto.ProjectResponseDTO;
+import com.umc.site.domain.project.entity.Project;
+
+import java.util.List;
+
+public interface ProjectQueryService {
+
+    // 기수별 프로젝트 목록 조회
+    List<ProjectResponseDTO.ProjectPreviewDTO> getProjectPreviewList(Long cohortId);
+}

--- a/src/main/java/com/umc/site/domain/project/service/ProjectQueryServiceImpl.java
+++ b/src/main/java/com/umc/site/domain/project/service/ProjectQueryServiceImpl.java
@@ -1,0 +1,36 @@
+package com.umc.site.domain.project.service;
+
+import com.umc.site.domain.image.entity.Image;
+import com.umc.site.domain.image.repository.ImageRepository;
+import com.umc.site.domain.project.converter.ProjectConverter;
+import com.umc.site.domain.project.dto.ProjectResponseDTO;
+import com.umc.site.domain.project.entity.Project;
+import com.umc.site.domain.project.repository.ProjectRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ProjectQueryServiceImpl implements ProjectQueryService{
+    private final ProjectRepository projectRepository;
+    private final ImageRepository imageRepository;
+
+    // 기수별 프로젝트 목록 조회
+    @Override
+    public List<ProjectResponseDTO.ProjectPreviewDTO> getProjectPreviewList(Long cohortId){
+        List<Project> projects = projectRepository.findAllByCohortId(cohortId);
+
+        return projects.stream()
+                .map(project -> {
+                    Image image = imageRepository.findByProject(project);
+
+                    return ProjectConverter.toProjectPreviewDTO(project, image);
+                })
+                .collect(Collectors.toList());
+    }
+}


### PR DESCRIPTION
## 🛰️ Issue Number
- resolve #2 

## 📝 작업 내용
-  엔티티를 추가했습니다.
- 각 엔티티에 맞는 DTO와 Converter를 구현했습니다.
- 각 엔티티의 Repository를 구현했습니다.
- Service에서 DTO를 반환하도록 구현했습니다.

## 💬 리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
