### PR TITLE
Feat: 프로젝트 상세 정보 조회 API 구현

### DIFF
--- a/src/main/java/com/umc/site/domain/club_admin/dto/ClubAdminResponseDTO.java
+++ b/src/main/java/com/umc/site/domain/club_admin/dto/ClubAdminResponseDTO.java
@@ -1,6 +1,6 @@
 package com.umc.site.domain.club_admin.dto;
 
-import com.umc.site.domain.club_admin.enums.Role;
+import com.umc.site.domain.club_admin.entity.enums.Role;
 import com.umc.site.domain.image.dto.ImageResponseDTO;
 import com.umc.site.domain.role_history.dto.RoleHistoryResponseDTO;
 import lombok.AllArgsConstructor;

--- a/src/main/java/com/umc/site/domain/club_admin/entity/ClubAdmin.java
+++ b/src/main/java/com/umc/site/domain/club_admin/entity/ClubAdmin.java
@@ -1,6 +1,6 @@
 package com.umc.site.domain.club_admin.entity;
 
-import com.umc.site.domain.club_admin.enums.Role;
+import com.umc.site.domain.club_admin.entity.enums.Role;
 import com.umc.site.domain.role_history.entity.RoleHistory;
 import com.umc.site.global.common.BaseEntity;
 import jakarta.persistence.*;

--- a/src/main/java/com/umc/site/domain/club_admin/entity/enums/Role.java
+++ b/src/main/java/com/umc/site/domain/club_admin/entity/enums/Role.java
@@ -1,4 +1,4 @@
-package com.umc.site.domain.club_admin.enums;
+package com.umc.site.domain.club_admin.entity.enums;
 
 public enum Role {
 

--- a/src/main/java/com/umc/site/domain/feature/converter/FeatureConverter.java
+++ b/src/main/java/com/umc/site/domain/feature/converter/FeatureConverter.java
@@ -1,0 +1,14 @@
+package com.umc.site.domain.feature.converter;
+
+import com.umc.site.domain.feature.dto.FeatureResponseDTO;
+import com.umc.site.domain.feature.entity.Feature;
+
+public class FeatureConverter {
+
+    public static FeatureResponseDTO.FeatureDTO toFeatureDTO(Feature feature) {
+
+        return FeatureResponseDTO.FeatureDTO.builder()
+                .content(feature.getContent())
+                .build();
+    }
+}

--- a/src/main/java/com/umc/site/domain/feature/dto/FeatureResponseDTO.java
+++ b/src/main/java/com/umc/site/domain/feature/dto/FeatureResponseDTO.java
@@ -1,0 +1,17 @@
+package com.umc.site.domain.feature.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class FeatureResponseDTO {
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class FeatureDTO {
+        private String content;
+    }
+}

--- a/src/main/java/com/umc/site/domain/feature/repository/FeatureRepository.java
+++ b/src/main/java/com/umc/site/domain/feature/repository/FeatureRepository.java
@@ -1,7 +1,11 @@
 package com.umc.site.domain.feature.repository;
 
 import com.umc.site.domain.feature.entity.Feature;
+import com.umc.site.domain.project.entity.Project;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface FeatureRepository extends JpaRepository<Feature, Long> {
+    List<Feature> findAllByProject(Project project);
 }

--- a/src/main/java/com/umc/site/domain/project/controller/ProjectController.java
+++ b/src/main/java/com/umc/site/domain/project/controller/ProjectController.java
@@ -27,4 +27,15 @@ public class ProjectController {
 
         return ApiResponse.onSuccess(projectQueryService.getProjectPreviewList(cohortId));
     }
+
+    // 프로젝트 상세 보기
+    @Operation(summary = "프로젝트 상세 정보 조회", description = "프로젝트 상세 정보를 불러옵니다.")
+    @GetMapping("/projects/{projectId}")
+    @Parameters({
+            @Parameter(name = "projectId", description = "프로젝트의 ID, pathVariable 입니다.")
+    })
+    public ApiResponse<ProjectResponseDTO.ProjectDetailDTO> getProjectDetails(@PathVariable(name = "projectId") Long projectId) {
+
+        return ApiResponse.onSuccess(projectQueryService.getProjectDetails(projectId));
+    }
 }

--- a/src/main/java/com/umc/site/domain/project/converter/ProjectConverter.java
+++ b/src/main/java/com/umc/site/domain/project/converter/ProjectConverter.java
@@ -1,9 +1,13 @@
 package com.umc.site.domain.project.converter;
 
+import com.umc.site.domain.feature.converter.FeatureConverter;
+import com.umc.site.domain.feature.entity.Feature;
 import com.umc.site.domain.image.converter.ImageConverter;
 import com.umc.site.domain.image.entity.Image;
 import com.umc.site.domain.project.dto.ProjectResponseDTO;
 import com.umc.site.domain.project.entity.Project;
+
+import java.util.List;
 
 public class ProjectConverter {
 
@@ -16,7 +20,28 @@ public class ProjectConverter {
                 .pm(project.getPm())
                 .frontEnd(project.getFrontEnd())
                 .backEnd(project.getBackEnd())
+                .design(project.getDesign())
                 .serviceType(project.getServiceType())
+                .image(ImageConverter.toImageDTO(image))
+                .build();
+    }
+
+    // 프로젝트 상세 정보 조회
+    public static ProjectResponseDTO.ProjectDetailDTO toProjectDetailDTO(Project project, Image image, List<Feature> features) {
+
+        return ProjectResponseDTO.ProjectDetailDTO.builder()
+                .projectId(project.getId())
+                .title(project.getTitle())
+                .serviceType(project.getServiceType())
+                .pm(project.getPm())
+                .frontEnd(project.getFrontEnd())
+                .backEnd(project.getBackEnd())
+                .design(project.getDesign())
+                .description(project.getDescription())
+                .cohort(project.getCohort().getName())
+                .features(features.stream()
+                        .map(FeatureConverter::toFeatureDTO)
+                        .toList())
                 .image(ImageConverter.toImageDTO(image))
                 .build();
     }

--- a/src/main/java/com/umc/site/domain/project/dto/ProjectResponseDTO.java
+++ b/src/main/java/com/umc/site/domain/project/dto/ProjectResponseDTO.java
@@ -1,11 +1,14 @@
 package com.umc.site.domain.project.dto;
 
+import com.umc.site.domain.feature.dto.FeatureResponseDTO;
 import com.umc.site.domain.image.dto.ImageResponseDTO;
 import com.umc.site.domain.project.enums.ServiceType;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.util.List;
 
 public class ProjectResponseDTO {
 
@@ -22,6 +25,25 @@ public class ProjectResponseDTO {
         private String backEnd;
         private String design;
         private ServiceType serviceType;
+        private ImageResponseDTO.ImageDTO image;
+    }
+
+    // 프로젝트 상세 정보 조회
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ProjectDetailDTO {
+        private Long projectId;
+        private String cohort;
+        private String title;
+        private ServiceType serviceType;
+        private String pm;
+        private String frontEnd;
+        private String backEnd;
+        private String design;
+        private String description;
+        private List<FeatureResponseDTO.FeatureDTO> features;
         private ImageResponseDTO.ImageDTO image;
     }
 }

--- a/src/main/java/com/umc/site/domain/project/service/ProjectQueryService.java
+++ b/src/main/java/com/umc/site/domain/project/service/ProjectQueryService.java
@@ -1,7 +1,6 @@
 package com.umc.site.domain.project.service;
 
 import com.umc.site.domain.project.dto.ProjectResponseDTO;
-import com.umc.site.domain.project.entity.Project;
 
 import java.util.List;
 
@@ -9,4 +8,7 @@ public interface ProjectQueryService {
 
     // 기수별 프로젝트 목록 조회
     List<ProjectResponseDTO.ProjectPreviewDTO> getProjectPreviewList(Long cohortId);
+
+    // 프로젝트 상세 정보 조회
+    ProjectResponseDTO.ProjectDetailDTO getProjectDetails(Long projectId);
 }

--- a/src/main/java/com/umc/site/domain/project/service/ProjectQueryServiceImpl.java
+++ b/src/main/java/com/umc/site/domain/project/service/ProjectQueryServiceImpl.java
@@ -1,11 +1,15 @@
 package com.umc.site.domain.project.service;
 
+import com.umc.site.domain.feature.entity.Feature;
+import com.umc.site.domain.feature.repository.FeatureRepository;
 import com.umc.site.domain.image.entity.Image;
 import com.umc.site.domain.image.repository.ImageRepository;
 import com.umc.site.domain.project.converter.ProjectConverter;
 import com.umc.site.domain.project.dto.ProjectResponseDTO;
 import com.umc.site.domain.project.entity.Project;
 import com.umc.site.domain.project.repository.ProjectRepository;
+import com.umc.site.global.apiPayload.code.status.ErrorStatus;
+import com.umc.site.global.apiPayload.exception.handler.ProjectHandler;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -19,6 +23,7 @@ import java.util.stream.Collectors;
 public class ProjectQueryServiceImpl implements ProjectQueryService{
     private final ProjectRepository projectRepository;
     private final ImageRepository imageRepository;
+    private final FeatureRepository featureRepository;
 
     // 기수별 프로젝트 목록 조회
     @Override
@@ -32,5 +37,15 @@ public class ProjectQueryServiceImpl implements ProjectQueryService{
                     return ProjectConverter.toProjectPreviewDTO(project, image);
                 })
                 .collect(Collectors.toList());
+    }
+
+    // 프로젝트 상세 정보 조회
+    @Override
+    public ProjectResponseDTO.ProjectDetailDTO getProjectDetails(Long projectId) {
+        Project project = projectRepository.findById(projectId).orElseThrow(() -> new ProjectHandler(ErrorStatus.PROJECT_NOT_FOUND));
+        Image image = imageRepository.findByProject(project);
+        List<Feature> features = featureRepository.findAllByProject(project);
+
+        return ProjectConverter.toProjectDetailDTO(project, image, features);
     }
 }

--- a/src/main/java/com/umc/site/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/umc/site/global/apiPayload/code/status/ErrorStatus.java
@@ -13,7 +13,11 @@ public enum ErrorStatus implements BaseErrorCode {
     _INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON500", "서버 에러, 관리자에게 문의 바랍니다."),
     _BAD_REQUEST(HttpStatus.BAD_REQUEST,"COMMON400","잘못된 요청입니다."),
     _UNAUTHORIZED(HttpStatus.UNAUTHORIZED,"COMMON401","인증이 필요합니다."),
-    _FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON403", "금지된 요청입니다.");
+    _FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON403", "금지된 요청입니다."),
+
+    // 프로젝트 관련 에러
+    PROJECT_NOT_FOUND(HttpStatus.NOT_FOUND, "PROJECT4001", "존재하지 않는 프로젝트입니다.");
+
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/umc/site/global/apiPayload/exception/handler/ProjectHandler.java
+++ b/src/main/java/com/umc/site/global/apiPayload/exception/handler/ProjectHandler.java
@@ -1,0 +1,10 @@
+package com.umc.site.global.apiPayload.exception.handler;
+
+import com.umc.site.global.apiPayload.code.BaseErrorCode;
+import com.umc.site.global.apiPayload.exception.GeneralException;
+
+public class ProjectHandler extends GeneralException {
+    public ProjectHandler(BaseErrorCode errorCode) {
+        super(errorCode);
+    }
+}


### PR DESCRIPTION
## 🛰️ Issue Number
- resolve #6 

## 📝 작업 내용
-   추가적으로 필요한 ResponseDTO와 Converter를 작성했습니다.
- 상세 정보 조회를 위한 Repository와 Service를 작성했습니다.
- projectId에 해당하는 프로젝트가 없는 경우의 ErrorStatus를 추가했습니다.

## 💬 리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
