### PR TITLE
Feat: 프로젝트 기수 생성 API 구현

### DIFF
--- a/src/main/java/com/umc/site/SiteApplication.java
+++ b/src/main/java/com/umc/site/SiteApplication.java
@@ -2,7 +2,9 @@ package com.umc.site;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class SiteApplication {
 

--- a/src/main/java/com/umc/site/domain/cohort/controller/CohortController.java
+++ b/src/main/java/com/umc/site/domain/cohort/controller/CohortController.java
@@ -1,14 +1,15 @@
 package com.umc.site.domain.cohort.controller;
 
+import com.umc.site.domain.cohort.dto.CohortRequestDTO;
 import com.umc.site.domain.cohort.dto.CohortResponseDTO;
+import com.umc.site.domain.cohort.service.CohortCommandService;
 import com.umc.site.domain.cohort.service.CohortQueryService;
 import com.umc.site.global.apiPayload.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameters;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -17,6 +18,7 @@ import java.util.List;
 @RequiredArgsConstructor
 public class CohortController {
     private final CohortQueryService cohortQueryService;
+    private final CohortCommandService cohortCommandService;
 
     // 기수 목록 조회
     @Operation(summary = "기수 목록 조회", description = "프로젝트를 불러오기 위한 기수 리스트를 불러옵니다.")
@@ -24,5 +26,13 @@ public class CohortController {
     public ApiResponse<List<CohortResponseDTO.CohortInfoDTO>> getCohorts() {
 
         return ApiResponse.onSuccess(cohortQueryService.getCohortList());
+    }
+
+    // 기수 추가
+    @Operation(summary = "기수 생성", description = "프로젝트 새 기수를 추가합니다.")
+    @PostMapping("/projects/cohort")
+    public ApiResponse<CohortResponseDTO.CreateCohortResultDTO> createCohort(@RequestBody @Valid CohortRequestDTO.CreateCohortDTO request) {
+
+        return ApiResponse.onSuccess(cohortCommandService.createCohort(request));
     }
 }

--- a/src/main/java/com/umc/site/domain/cohort/converter/CohortConverter.java
+++ b/src/main/java/com/umc/site/domain/cohort/converter/CohortConverter.java
@@ -1,6 +1,7 @@
 package com.umc.site.domain.cohort.converter;
 
 
+import com.umc.site.domain.cohort.dto.CohortRequestDTO;
 import com.umc.site.domain.cohort.dto.CohortResponseDTO;
 import com.umc.site.domain.cohort.entity.Cohort;
 
@@ -12,6 +13,23 @@ public class CohortConverter {
         return CohortResponseDTO.CohortInfoDTO.builder()
                 .cohortId(cohort.getId())
                 .name(cohort.getName())
+                .build();
+    }
+
+    public static Cohort toCohort(CohortRequestDTO.CreateCohortDTO request){
+
+        return Cohort.builder()
+                .name(request.getName())
+                .build();
+    }
+
+    // 기수 생성
+    public static CohortResponseDTO.CreateCohortResultDTO toCreateCohortResultDTO(Cohort cohort){
+
+        return CohortResponseDTO.CreateCohortResultDTO.builder()
+                .cohortId(cohort.getId())
+                .name(cohort.getName())
+                .createdAt(cohort.getCreatedAt())
                 .build();
     }
 }

--- a/src/main/java/com/umc/site/domain/cohort/dto/CohortRequestDTO.java
+++ b/src/main/java/com/umc/site/domain/cohort/dto/CohortRequestDTO.java
@@ -1,0 +1,14 @@
+package com.umc.site.domain.cohort.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+public class CohortRequestDTO {
+
+    // 기수 추가
+    @Getter
+    public static class CreateCohortDTO {
+        @NotBlank
+        private String name;
+    }
+}

--- a/src/main/java/com/umc/site/domain/cohort/dto/CohortResponseDTO.java
+++ b/src/main/java/com/umc/site/domain/cohort/dto/CohortResponseDTO.java
@@ -1,9 +1,12 @@
 package com.umc.site.domain.cohort.dto;
 
+import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
 
 public class CohortResponseDTO {
 
@@ -15,5 +18,16 @@ public class CohortResponseDTO {
     public static class CohortInfoDTO {
         private Long cohortId;
         private String name;
+    }
+
+    // 기수 추가
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class CreateCohortResultDTO {
+        private Long cohortId;
+        private String name;
+        LocalDateTime createdAt;
     }
 }

--- a/src/main/java/com/umc/site/domain/cohort/service/CohortCommandService.java
+++ b/src/main/java/com/umc/site/domain/cohort/service/CohortCommandService.java
@@ -1,0 +1,10 @@
+package com.umc.site.domain.cohort.service;
+
+import com.umc.site.domain.cohort.dto.CohortRequestDTO;
+import com.umc.site.domain.cohort.dto.CohortResponseDTO;
+
+public interface CohortCommandService {
+
+    // 기수 추가
+    CohortResponseDTO.CreateCohortResultDTO createCohort(CohortRequestDTO.CreateCohortDTO request);
+}

--- a/src/main/java/com/umc/site/domain/cohort/service/CohortCommandServiceImpl.java
+++ b/src/main/java/com/umc/site/domain/cohort/service/CohortCommandServiceImpl.java
@@ -1,0 +1,28 @@
+package com.umc.site.domain.cohort.service;
+
+import com.umc.site.domain.cohort.converter.CohortConverter;
+import com.umc.site.domain.cohort.dto.CohortRequestDTO;
+import com.umc.site.domain.cohort.dto.CohortResponseDTO;
+import com.umc.site.domain.cohort.entity.Cohort;
+import com.umc.site.domain.cohort.repository.CohortRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class CohortCommandServiceImpl implements CohortCommandService {
+
+    private final CohortRepository cohortRepository;
+
+    // 기수 추가
+    @Override
+    @Transactional
+    public CohortResponseDTO.CreateCohortResultDTO createCohort(CohortRequestDTO.CreateCohortDTO request){
+        Cohort cohort = CohortConverter.toCohort(request);
+
+        cohort = cohortRepository.save(cohort);
+
+        return CohortConverter.toCreateCohortResultDTO(cohort);
+    }
+}


### PR DESCRIPTION
## 🛰️ Issue Number
- resolve #20 

## 📝 작업 내용
- 프로젝트 페이지 내 기수 목록 생성 api를 구현했습니다
- 관련 dto를 추가했습니다.
- 관련 converter를 추가했습니다. 
- 관련 service를 추가했습니다.
- 관련 controller를 추가했습니다.
- createAt 자동 입력을 위해 Application에 @EnableJpaAuditing 추가했습니다.

## 💬 리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
