### PR TITLE
Feat: 운영진 리스트 조회 API에서 운영진 직책 가져오는 로직 수정

### DIFF
--- a/src/main/java/com/umc/site/domain/club_admin/converter/ClubAdminConverter.java
+++ b/src/main/java/com/umc/site/domain/club_admin/converter/ClubAdminConverter.java
@@ -13,14 +13,15 @@ import java.util.List;
 public class ClubAdminConverter {
 
     // 운영진 리스트 조회
-    public static ClubAdminResponseDTO.ClubAdminInfoDTO toClubAdminInfoDTO(ClubAdmin clubAdmin, Image image, List<RoleHistory> roleHistories) {
+    public static ClubAdminResponseDTO.ClubAdminInfoDTO toClubAdminInfoDTO(ClubAdmin clubAdmin, Image image,
+                                                                           List<RoleHistory> roleHistories, String role) {
 
         return ClubAdminResponseDTO.ClubAdminInfoDTO.builder()
                 .clubAdminId(clubAdmin.getId())
                 .name(clubAdmin.getName())
                 .nickname(clubAdmin.getNickname())
                 .commitment(clubAdmin.getCommitment())
-                .role(clubAdmin.getRole())
+                .role(role)
                 .image(ImageConverter.toImageDTO(image))
                 .roleHistories(roleHistories.stream()
                         .map(RoleHistoryConverter::toRoleHistoryDTO)

--- a/src/main/java/com/umc/site/domain/club_admin/dto/ClubAdminResponseDTO.java
+++ b/src/main/java/com/umc/site/domain/club_admin/dto/ClubAdminResponseDTO.java
@@ -23,7 +23,7 @@ public class ClubAdminResponseDTO {
         String name;
         String nickname;
         String commitment;
-        Role role;
+        String role;
         ImageResponseDTO.ImageDTO image;
         List<RoleHistoryResponseDTO.RoleHistoryDTO> roleHistories;
     }

--- a/src/main/java/com/umc/site/domain/club_admin/service/ClubAdminQueryServiceImpl.java
+++ b/src/main/java/com/umc/site/domain/club_admin/service/ClubAdminQueryServiceImpl.java
@@ -31,10 +31,23 @@ public class ClubAdminQueryServiceImpl implements ClubAdminQueryService{
 
         return clubAdmins.stream()
                 .map(clubAdmin -> {
+                    String role = switch (clubAdmin.getRole()) {
+                        case PRESIDENT -> "회장";
+                        case VICE_PRESIDENT -> "부회장";
+                        case MANAGE_LEADER -> "운영팀장";
+                        case PLAN_LEADER -> "Plan 파트장";
+                        case DESIGN_LEADER -> "Design 파트장";
+                        case SPRING_BOOT_LEADER -> "SpringBoot 파트장";
+                        case NODEJS_LEADER -> "Node.js 파트장";
+                        case WEB_LEADER -> "Web 파트장";
+                        case ANDROID_LEADER -> "Android 파트장";
+                        case IOS_LEADER -> "IOS 파트장";
+                    };
+
                     Image image = imageRepository.findByClubAdmin(clubAdmin);
                     List<RoleHistory> roleHistories = roleHistoryRepository.findAllByClubAdmin(clubAdmin);
 
-                    return ClubAdminConverter.toClubAdminInfoDTO(clubAdmin, image, roleHistories);
+                    return ClubAdminConverter.toClubAdminInfoDTO(clubAdmin, image, roleHistories, role);
                 })
                 .collect(Collectors.toList());
     }


### PR DESCRIPTION
## 🛰️ Issue Number
- resolve #29 

## 📝 작업 내용
-   운영진 조회 responseDTO에 role 타입을 Role -> String으로 변경했습니다.
- switch 문을 사용해서 role에 들어갈 값을 대입했습니다.

## 💬 리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
