### PR TITLE
Feat: 프로젝트 기수 수정 API 구현

### DIFF
--- a/src/main/java/com/umc/site/domain/cohort/controller/CohortController.java
+++ b/src/main/java/com/umc/site/domain/cohort/controller/CohortController.java
@@ -6,6 +6,7 @@ import com.umc.site.domain.cohort.service.CohortCommandService;
 import com.umc.site.domain.cohort.service.CohortQueryService;
 import com.umc.site.global.apiPayload.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -34,5 +35,16 @@ public class CohortController {
     public ApiResponse<CohortResponseDTO.CreateCohortResultDTO> createCohort(@RequestBody @Valid CohortRequestDTO.CreateCohortDTO request) {
 
         return ApiResponse.onSuccess(cohortCommandService.createCohort(request));
+    }
+
+    // 기수 수정
+    @Operation(summary = "기수 수정", description = "프로젝트 기존 기수를 수정합니다.")
+    @PatchMapping("/projects/cohort/{cohortId}")
+    @Parameters({
+            @Parameter(name = "cohortId", description = "기수의 ID, cohortId 입니다.")
+    })
+    public ApiResponse<CohortResponseDTO.UpdateCohortResultDTO> updateCohort(@PathVariable(name = "cohortId") Long cohortId, @RequestBody @Valid CohortRequestDTO.UpdateCohortDTO request) {
+
+        return ApiResponse.onSuccess(cohortCommandService.updateCohort(cohortId, request));
     }
 }

--- a/src/main/java/com/umc/site/domain/cohort/converter/CohortConverter.java
+++ b/src/main/java/com/umc/site/domain/cohort/converter/CohortConverter.java
@@ -32,4 +32,14 @@ public class CohortConverter {
                 .createdAt(cohort.getCreatedAt())
                 .build();
     }
+
+    // 기수 수정
+    public static CohortResponseDTO.UpdateCohortResultDTO toUpdateCohortResultDTO(Cohort cohort){
+
+        return CohortResponseDTO.UpdateCohortResultDTO.builder()
+                .cohortId(cohort.getId())
+                .name(cohort.getName())
+                .updatedAt(cohort.getUpdatedAt())
+                .build();
+    }
 }

--- a/src/main/java/com/umc/site/domain/cohort/dto/CohortRequestDTO.java
+++ b/src/main/java/com/umc/site/domain/cohort/dto/CohortRequestDTO.java
@@ -11,4 +11,11 @@ public class CohortRequestDTO {
         @NotBlank
         private String name;
     }
+
+    // 기수 수정
+    @Getter
+    public static class UpdateCohortDTO {
+        @NotBlank
+        private String name;
+    }
 }

--- a/src/main/java/com/umc/site/domain/cohort/dto/CohortResponseDTO.java
+++ b/src/main/java/com/umc/site/domain/cohort/dto/CohortResponseDTO.java
@@ -28,6 +28,17 @@ public class CohortResponseDTO {
     public static class CreateCohortResultDTO {
         private Long cohortId;
         private String name;
-        LocalDateTime createdAt;
+        private LocalDateTime createdAt;
+    }
+
+    // 기수 수정
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class UpdateCohortResultDTO {
+        private Long cohortId;
+        private String name;
+        private LocalDateTime updatedAt;
     }
 }

--- a/src/main/java/com/umc/site/domain/cohort/entity/Cohort.java
+++ b/src/main/java/com/umc/site/domain/cohort/entity/Cohort.java
@@ -20,6 +20,7 @@ public class Cohort extends BaseEntity {
     private Long id;
 
     // 기수명 (ex. 7기)
+    @Setter
     @Column(nullable = false, length = 20)
     private String name;
 

--- a/src/main/java/com/umc/site/domain/cohort/service/CohortCommandService.java
+++ b/src/main/java/com/umc/site/domain/cohort/service/CohortCommandService.java
@@ -7,4 +7,7 @@ public interface CohortCommandService {
 
     // 기수 추가
     CohortResponseDTO.CreateCohortResultDTO createCohort(CohortRequestDTO.CreateCohortDTO request);
+
+    // 기수 수정
+    CohortResponseDTO.UpdateCohortResultDTO updateCohort(Long cohortId, CohortRequestDTO.UpdateCohortDTO request);
 }

--- a/src/main/java/com/umc/site/domain/cohort/service/CohortCommandServiceImpl.java
+++ b/src/main/java/com/umc/site/domain/cohort/service/CohortCommandServiceImpl.java
@@ -5,6 +5,8 @@ import com.umc.site.domain.cohort.dto.CohortRequestDTO;
 import com.umc.site.domain.cohort.dto.CohortResponseDTO;
 import com.umc.site.domain.cohort.entity.Cohort;
 import com.umc.site.domain.cohort.repository.CohortRepository;
+import com.umc.site.global.apiPayload.code.status.ErrorStatus;
+import com.umc.site.global.apiPayload.exception.handler.CohortHandler;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -24,5 +26,20 @@ public class CohortCommandServiceImpl implements CohortCommandService {
         cohort = cohortRepository.save(cohort);
 
         return CohortConverter.toCreateCohortResultDTO(cohort);
+    }
+
+
+    // 기수 수정
+    @Override
+    @Transactional
+    public CohortResponseDTO.UpdateCohortResultDTO updateCohort(Long cohortId, CohortRequestDTO.UpdateCohortDTO request){
+        Cohort cohort = cohortRepository.findById(cohortId)
+                .orElseThrow(() -> new CohortHandler(ErrorStatus.COHORT_NOT_FOUND));
+
+        cohort.setName(request.getName());
+
+        cohort = cohortRepository.save(cohort);
+
+        return CohortConverter.toUpdateCohortResultDTO(cohort);
     }
 }

--- a/src/main/java/com/umc/site/global/apiPayload/exception/handler/CohortHandler.java
+++ b/src/main/java/com/umc/site/global/apiPayload/exception/handler/CohortHandler.java
@@ -1,0 +1,10 @@
+package com.umc.site.global.apiPayload.exception.handler;
+
+import com.umc.site.global.apiPayload.code.BaseErrorCode;
+import com.umc.site.global.apiPayload.exception.GeneralException;
+
+public class CohortHandler extends GeneralException {
+    public CohortHandler(BaseErrorCode errorCode) {
+        super(errorCode);
+    }
+}


### PR DESCRIPTION
## 🛰️ Issue Number
- resolve #24 

## 📝 작업 내용
- 프로젝트 기수 수정 API 구현했습니다.
- 관련 dto 추가했습니다.
- 관련 service 추가했습니다.
- 관련 converter 추가했습니다.
- 관련 controller 추가했습니다.
- 관련 handler 추가했습니다.
- cohort 엔티티의 이름 속성에 setter 추가했습니다.

## 💬 리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
