### PR TITLE
Feat: 프로젝트 수정 API 구현

### DIFF
--- a/src/main/java/com/umc/site/domain/feature/repository/FeatureRepository.java
+++ b/src/main/java/com/umc/site/domain/feature/repository/FeatureRepository.java
@@ -8,4 +8,6 @@ import java.util.List;
 
 public interface FeatureRepository extends JpaRepository<Feature, Long> {
     List<Feature> findAllByProject(Project project);
+
+    void deleteAllByProjectId(Long projectId);
 }

--- a/src/main/java/com/umc/site/domain/image/entity/Image.java
+++ b/src/main/java/com/umc/site/domain/image/entity/Image.java
@@ -32,7 +32,7 @@ public class Image extends BaseEntity {
     private ClubAdmin clubAdmin;
 
     @Setter
-    @OneToOne(cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "project_id", referencedColumnName = "id")
     private Project project;
 }

--- a/src/main/java/com/umc/site/domain/image/service/ImageCommandService.java
+++ b/src/main/java/com/umc/site/domain/image/service/ImageCommandService.java
@@ -9,6 +9,9 @@ public interface ImageCommandService {
     // 프로젝트 사진 생성
     void createProjectImage(MultipartFile file, Project project);
 
+    // 프로젝트 사진 삭제
+    void deleteProjectImage(Project project);
+
     // 운영진 사진 생성
     void createClubAdminImage(MultipartFile file, ClubAdmin clubAdmin);
 }

--- a/src/main/java/com/umc/site/domain/image/service/ImageCommandServiceImpl.java
+++ b/src/main/java/com/umc/site/domain/image/service/ImageCommandServiceImpl.java
@@ -32,6 +32,19 @@ public class ImageCommandServiceImpl implements ImageCommandService {
         imageRepository.save(image);
     }
 
+    // 프로젝트 사진 삭제
+    @Override
+    @Transactional
+    public void deleteProjectImage(Project project){
+
+        Image image = imageRepository.findByProject(project);
+
+        s3Manager.deleteFile(image.getFileName());
+
+        imageRepository.delete(image);
+        imageRepository.flush();
+    }
+
     // 운영진 사진 생성
     @Override
     @Transactional

--- a/src/main/java/com/umc/site/domain/project/controller/ProjectController.java
+++ b/src/main/java/com/umc/site/domain/project/controller/ProjectController.java
@@ -69,4 +69,17 @@ public class ProjectController {
 
         return ApiResponse.onSuccess(projectCommandService.createProject(request, file));
     }
+
+    // 프로젝트 수정
+    @Operation(summary = "프로젝트 수정", description = "프로젝트를 수정합니다. 이미지는 같이 보내야 바뀌고 안보내면 이전 이미지로 유지됩니다.")
+    @PatchMapping(value =  "/projects/{projectId}", consumes = {MediaType.MULTIPART_FORM_DATA_VALUE})
+    @Parameters({
+            @Parameter(name = "projectId", description = "수정할 프로젝트의 ID, pathVariable 입니다.")
+    })
+    public ApiResponse<ProjectResponseDTO.UpdateProjectResultDTO> updateProject(@PathVariable(name = "projectId") Long projectId,
+                                                                                @RequestPart("request") @Valid ProjectRequestDTO.UpdateProjectDTO request,
+                                                                                @RequestPart(value = "file", required = false) MultipartFile file) {
+
+        return ApiResponse.onSuccess(projectCommandService.updateProject(projectId, request, file));
+    }
 }

--- a/src/main/java/com/umc/site/domain/project/converter/ProjectConverter.java
+++ b/src/main/java/com/umc/site/domain/project/converter/ProjectConverter.java
@@ -77,4 +77,11 @@ public class ProjectConverter {
                 .createdAt(project.getCreatedAt())
                 .build();
     }
+
+    public static ProjectResponseDTO.UpdateProjectResultDTO toUpdateProjectResultDTO(Project project) {
+        return ProjectResponseDTO.UpdateProjectResultDTO.builder()
+                .projectId(project.getId())
+                .updatedAt(project.getUpdatedAt())
+                .build();
+    }
 }

--- a/src/main/java/com/umc/site/domain/project/dto/ProjectRequestDTO.java
+++ b/src/main/java/com/umc/site/domain/project/dto/ProjectRequestDTO.java
@@ -1,6 +1,5 @@
 package com.umc.site.domain.project.dto;
 
-import com.umc.site.domain.cohort.entity.Cohort;
 import com.umc.site.domain.feature.dto.FeatureRequestDTO;
 import com.umc.site.domain.project.enums.ServiceType;
 import jakarta.validation.constraints.NotBlank;
@@ -51,5 +50,37 @@ public class ProjectRequestDTO {
         // 프로젝트 핵심 기능
         @Size(min = 1)
         private List<FeatureRequestDTO.CreatFeatureDTO> featureList;
+    }
+
+    // 프로젝트 수정
+    @Getter
+    public static class UpdateProjectDTO {
+
+        @NotBlank
+        private String title;   // 프로젝트명
+
+        @NotBlank
+        private String pm;  // 기획 사람들
+
+        @NotBlank
+        private String frontEnd;    // 프론트엔드 사람들
+
+        @NotBlank
+        private String backEnd; // 백엔드 사람들
+
+        @NotBlank
+        private String design;  // 디자인 사람들
+
+        @NotNull(message = "WEB/IOS/ANDROID")
+        private ServiceType serviceType;    // 서비스 유형
+
+        @NotBlank
+        private String description;  // 프로젝트 설명
+
+        @NotNull
+        private Long cohortId;  // 기수
+
+        @Size(min = 1)
+        private List<FeatureRequestDTO.CreatFeatureDTO> featureList;    // 프로젝트 핵심 기능
     }
 }

--- a/src/main/java/com/umc/site/domain/project/dto/ProjectResponseDTO.java
+++ b/src/main/java/com/umc/site/domain/project/dto/ProjectResponseDTO.java
@@ -67,6 +67,16 @@ public class ProjectResponseDTO {
     @AllArgsConstructor
     public static class CreateProjectResultDTO {
         private Long projectId;
-        LocalDateTime createdAt;
+        private LocalDateTime createdAt;
+    }
+
+    // 프로젝트 수정
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class UpdateProjectResultDTO {
+        private Long projectId;
+        private LocalDateTime updatedAt;
     }
 }

--- a/src/main/java/com/umc/site/domain/project/entity/Project.java
+++ b/src/main/java/com/umc/site/domain/project/entity/Project.java
@@ -1,5 +1,6 @@
 package com.umc.site.domain.project.entity;
 
+import com.umc.site.domain.project.dto.ProjectRequestDTO;
 import com.umc.site.domain.project.enums.ServiceType;
 import com.umc.site.domain.cohort.entity.Cohort;
 import com.umc.site.domain.feature.entity.Feature;
@@ -58,4 +59,15 @@ public class Project extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "cohort_id")
     private Cohort cohort;
+
+    public void updateProject(ProjectRequestDTO.UpdateProjectDTO request, Cohort cohort) {
+        this.title = request.getTitle();
+        this.pm = request.getPm();
+        this.frontEnd = request.getFrontEnd();
+        this.backEnd = request.getBackEnd();
+        this.design = request.getDesign();
+        this.serviceType = request.getServiceType();
+        this.description = request.getDescription();
+        this.cohort = cohort;
+    }
 }

--- a/src/main/java/com/umc/site/domain/project/service/ProjectCommandService.java
+++ b/src/main/java/com/umc/site/domain/project/service/ProjectCommandService.java
@@ -9,4 +9,7 @@ import java.util.List;
 public interface ProjectCommandService {
     // 프로젝트 생성
     ProjectResponseDTO.CreateProjectResultDTO createProject(ProjectRequestDTO.CreateProjectDTO request, MultipartFile file);
+
+    // 프로젝트 수정
+    ProjectResponseDTO.UpdateProjectResultDTO updateProject(Long projectId, ProjectRequestDTO.UpdateProjectDTO request, MultipartFile file);
 }

--- a/src/main/java/com/umc/site/domain/project/service/ProjectCommandServiceImpl.java
+++ b/src/main/java/com/umc/site/domain/project/service/ProjectCommandServiceImpl.java
@@ -66,7 +66,7 @@ public class ProjectCommandServiceImpl implements ProjectCommandService{
     @Transactional
     public ProjectResponseDTO.UpdateProjectResultDTO updateProject(Long projectId, ProjectRequestDTO.UpdateProjectDTO request, MultipartFile file){
 
-        // 프로젝트 기수 찾기
+        // 프로젝트 찾기
         Project existProject = projectRepository.findById(projectId)
                 .orElseThrow(() -> new ProjectHandler(ErrorStatus.PROJECT_NOT_FOUND));
 

--- a/src/main/java/com/umc/site/global/manager/AmazonS3Manager.java
+++ b/src/main/java/com/umc/site/global/manager/AmazonS3Manager.java
@@ -1,6 +1,7 @@
 package com.umc.site.global.manager;
 
 import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.DeleteObjectRequest;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.PutObjectRequest;
 import com.umc.site.global.config.AmazonConfig;
@@ -32,6 +33,10 @@ public class AmazonS3Manager{
         }
 
         return amazonS3.getUrl(amazonConfig.getBucket(), keyName).toString();
+    }
+
+    public void deleteFile(String keyName) {
+        amazonS3.deleteObject(new DeleteObjectRequest(amazonConfig.getBucket(), keyName));
     }
 
     public String generateProjectKeyName() {


### PR DESCRIPTION
## 🛰️ Issue Number
- resolve #23 

## 📝 작업 내용
- 프로젝트 수정 api 구현했습니다.
- 이미지 바꾸기 위해 먼저 이미지 삭제하는 기능을 구현했습니다.
- 핵심 기능 바꾸기 위해 먼저 핵심 기능 삭제하는 기능을 구현했습니다.
- persist 에러를 막기 위해 CasecadeType.ALL을 제거했습니다.
- 프로젝트를 수정하기 위한 dto, service, converter, controller 등을 추가했습니다.
- 이미지의 경우 기존 이미지도 두고싶어할 경우를 고려하여 새로운 이미지도 같이 보내면 바꾸고, 이미지를 보내지 않으면 기존 이미지를 유지하도록 했습니다.

## 💬 리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
