### PR TITLE
Feat: 모집 중인 파트 조회 API, 커리큘럼 조회 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,7 @@ dependencies {
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
 	implementation 'jakarta.validation:jakarta.validation-api:3.0.2'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
 
 	// swagger
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'

--- a/src/main/java/com/umc/site/domain/curriculum/controller/CurriculumController.java
+++ b/src/main/java/com/umc/site/domain/curriculum/controller/CurriculumController.java
@@ -1,0 +1,38 @@
+package com.umc.site.domain.curriculum.controller;
+
+import com.umc.site.domain.curriculum.dto.CurriculumResponseDTO;
+import com.umc.site.domain.curriculum.service.CurriculumQueryService;
+import com.umc.site.domain.part.entity.enums.PartType;
+import com.umc.site.global.apiPayload.ApiResponse;
+import com.umc.site.global.validation.annotation.ValidPart;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import lombok.RequiredArgsConstructor;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+@Validated
+public class CurriculumController {
+
+    private final CurriculumQueryService curriculumQueryService;
+
+    // 파트별 커리큘럼 조회
+    @Operation(summary = "파트별 커리큘럼 조회", description = "파트별 커리큘럼 리스트를 불러옵니다.")
+    @GetMapping("/curriculums")
+    @Parameters ({
+            @Parameter(name = "partType", description = "커리큘럼의 파트를 특정합니다, query variable 입니다.")
+    })
+    public ApiResponse<List<CurriculumResponseDTO.CurriculumInfoDTO>> getCurriculums(@RequestParam(defaultValue = "PLAN") @ValidPart PartType partType) {
+
+        return ApiResponse.onSuccess(curriculumQueryService.getCurriculumList(partType));
+    }
+}

--- a/src/main/java/com/umc/site/domain/curriculum/converter/CurriculumConverter.java
+++ b/src/main/java/com/umc/site/domain/curriculum/converter/CurriculumConverter.java
@@ -1,0 +1,16 @@
+package com.umc.site.domain.curriculum.converter;
+
+import com.umc.site.domain.curriculum.dto.CurriculumResponseDTO;
+import com.umc.site.domain.curriculum.entity.Curriculum;
+
+public class CurriculumConverter {
+
+    public static CurriculumResponseDTO.CurriculumInfoDTO toCurriculumInfoDTO(Curriculum curriculum) {
+
+        return CurriculumResponseDTO.CurriculumInfoDTO.builder()
+                .curriculumId(curriculum.getId())
+                .week(curriculum.getWeek())
+                .content(curriculum.getContent())
+                .build();
+    }
+}

--- a/src/main/java/com/umc/site/domain/curriculum/dto/CurriculumResponseDTO.java
+++ b/src/main/java/com/umc/site/domain/curriculum/dto/CurriculumResponseDTO.java
@@ -1,0 +1,19 @@
+package com.umc.site.domain.curriculum.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class CurriculumResponseDTO {
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class CurriculumInfoDTO {
+        private Long curriculumId;
+        private Integer week;
+        private String content;
+    }
+}

--- a/src/main/java/com/umc/site/domain/curriculum/entity/Curriculum.java
+++ b/src/main/java/com/umc/site/domain/curriculum/entity/Curriculum.java
@@ -1,0 +1,28 @@
+package com.umc.site.domain.curriculum.entity;
+
+import com.umc.site.domain.part.entity.Part;
+import com.umc.site.global.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Curriculum extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private Integer week;
+
+    @Column(nullable = false, length = 200)
+    private String content;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "part_id")
+    private Part part;
+}

--- a/src/main/java/com/umc/site/domain/curriculum/repository/CurriculumRepository.java
+++ b/src/main/java/com/umc/site/domain/curriculum/repository/CurriculumRepository.java
@@ -1,0 +1,12 @@
+package com.umc.site.domain.curriculum.repository;
+
+import com.umc.site.domain.curriculum.entity.Curriculum;
+import com.umc.site.domain.part.entity.Part;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface CurriculumRepository extends JpaRepository<Curriculum, Long> {
+
+    List<Curriculum> findAllByPart(Part part);
+}

--- a/src/main/java/com/umc/site/domain/curriculum/service/CurriculumQueryService.java
+++ b/src/main/java/com/umc/site/domain/curriculum/service/CurriculumQueryService.java
@@ -1,0 +1,11 @@
+package com.umc.site.domain.curriculum.service;
+
+import com.umc.site.domain.curriculum.dto.CurriculumResponseDTO;
+import com.umc.site.domain.part.entity.enums.PartType;
+
+import java.util.List;
+
+public interface CurriculumQueryService {
+
+    List<CurriculumResponseDTO.CurriculumInfoDTO> getCurriculumList(PartType partType);
+}

--- a/src/main/java/com/umc/site/domain/curriculum/service/CurriculumQueryServiceImpl.java
+++ b/src/main/java/com/umc/site/domain/curriculum/service/CurriculumQueryServiceImpl.java
@@ -7,8 +7,6 @@ import com.umc.site.domain.curriculum.repository.CurriculumRepository;
 import com.umc.site.domain.part.entity.Part;
 import com.umc.site.domain.part.entity.enums.PartType;
 import com.umc.site.domain.part.repository.PartRepository;
-import com.umc.site.global.apiPayload.code.status.ErrorStatus;
-import com.umc.site.global.apiPayload.exception.handler.PartHandler;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -27,9 +25,6 @@ public class CurriculumQueryServiceImpl implements CurriculumQueryService {
     public List<CurriculumResponseDTO.CurriculumInfoDTO> getCurriculumList(PartType partType) {
 
         Part part = partRepository.findByPartType(partType);
-        if (!part.getIsRecruiting()) {
-            throw new PartHandler(ErrorStatus.PART_NOT_RECRUITNIG);
-        }
 
         List<Curriculum> curriculums = curriculumRepository.findAllByPart(part);
 

--- a/src/main/java/com/umc/site/domain/curriculum/service/CurriculumQueryServiceImpl.java
+++ b/src/main/java/com/umc/site/domain/curriculum/service/CurriculumQueryServiceImpl.java
@@ -1,0 +1,40 @@
+package com.umc.site.domain.curriculum.service;
+
+import com.umc.site.domain.curriculum.converter.CurriculumConverter;
+import com.umc.site.domain.curriculum.dto.CurriculumResponseDTO;
+import com.umc.site.domain.curriculum.entity.Curriculum;
+import com.umc.site.domain.curriculum.repository.CurriculumRepository;
+import com.umc.site.domain.part.entity.Part;
+import com.umc.site.domain.part.entity.enums.PartType;
+import com.umc.site.domain.part.repository.PartRepository;
+import com.umc.site.global.apiPayload.code.status.ErrorStatus;
+import com.umc.site.global.apiPayload.exception.handler.PartHandler;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CurriculumQueryServiceImpl implements CurriculumQueryService {
+
+    private final PartRepository partRepository;
+    private final CurriculumRepository curriculumRepository;
+
+    @Override
+    public List<CurriculumResponseDTO.CurriculumInfoDTO> getCurriculumList(PartType partType) {
+
+        Part part = partRepository.findByPartType(partType);
+        if (!part.getIsRecruiting()) {
+            throw new PartHandler(ErrorStatus.PART_NOT_RECRUITNIG);
+        }
+
+        List<Curriculum> curriculums = curriculumRepository.findAllByPart(part);
+
+        return curriculums.stream()
+                .map(CurriculumConverter::toCurriculumInfoDTO)
+                .toList();
+    }
+}

--- a/src/main/java/com/umc/site/domain/part/controller/PartController.java
+++ b/src/main/java/com/umc/site/domain/part/controller/PartController.java
@@ -1,0 +1,28 @@
+package com.umc.site.domain.part.controller;
+
+import com.umc.site.domain.part.dto.PartResponseDTO;
+import com.umc.site.domain.part.service.PartQueryService;
+import com.umc.site.global.apiPayload.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+public class PartController {
+
+    private final PartQueryService partQueryService;
+
+    // 모집 중인 파트 목록 조회
+    @Operation(summary = "모집 중인 파트 목록 조회", description = "커리큘럼 페이지에서 모집 중인 파트 목록을 불러옵니다.")
+    @GetMapping("/curriculums/part")
+    public ApiResponse<List<PartResponseDTO.RecruitingPartDTO>> getRecruitingParts() {
+
+        return ApiResponse.onSuccess(partQueryService.getRecruitingPartList());
+    }
+}

--- a/src/main/java/com/umc/site/domain/part/converter/PartConverter.java
+++ b/src/main/java/com/umc/site/domain/part/converter/PartConverter.java
@@ -1,0 +1,26 @@
+package com.umc.site.domain.part.converter;
+
+import com.umc.site.domain.part.dto.PartResponseDTO;
+import com.umc.site.domain.part.entity.Part;
+
+public class PartConverter {
+
+    public static PartResponseDTO.RecruitingPartDTO toRecruitingPartDTO (Part part) {
+
+        String name = switch (part.getPartType()) {
+            case SPRING_BOOT -> "SpringBoot";
+            case IOS -> "IOS";
+            case ANDROID -> "Android";
+            case WEB -> "Web";
+            case PLAN -> "Plan";
+            case DESIGN -> "Design";
+            case NODEJS -> "Node.js";
+        };
+
+        return PartResponseDTO.RecruitingPartDTO.builder()
+                .partId(part.getId())
+                .name(name)
+                .partType(part.getPartType())
+                .build();
+    }
+}

--- a/src/main/java/com/umc/site/domain/part/dto/PartResponseDTO.java
+++ b/src/main/java/com/umc/site/domain/part/dto/PartResponseDTO.java
@@ -1,0 +1,20 @@
+package com.umc.site.domain.part.dto;
+
+import com.umc.site.domain.part.entity.enums.PartType;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class PartResponseDTO {
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class RecruitingPartDTO {
+        private Long partId;
+        private PartType partType;
+        private String name;
+    }
+}

--- a/src/main/java/com/umc/site/domain/part/entity/Part.java
+++ b/src/main/java/com/umc/site/domain/part/entity/Part.java
@@ -1,0 +1,37 @@
+package com.umc.site.domain.part.entity;
+
+import com.umc.site.domain.curriculum.entity.Curriculum;
+import com.umc.site.domain.part.entity.enums.PartType;
+import com.umc.site.global.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.ColumnDefault;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Builder
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Part extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(columnDefinition = "VARCHAR(20)", unique = true)
+    private PartType partType;
+
+    @Column(nullable = false, length = 200)
+    private String introduce;
+
+    @Column(nullable = false)
+    @ColumnDefault("true")
+    private Boolean isRecruiting;
+
+    @OneToMany(cascade = CascadeType.ALL, mappedBy = "part")
+    private List<Curriculum> curriculums = new ArrayList<>();
+}

--- a/src/main/java/com/umc/site/domain/part/entity/enums/PartType.java
+++ b/src/main/java/com/umc/site/domain/part/entity/enums/PartType.java
@@ -1,0 +1,11 @@
+package com.umc.site.domain.part.entity.enums;
+
+public enum PartType {
+    SPRING_BOOT,
+    NODEJS,
+    WEB,
+    ANDROID,
+    IOS,
+    PLAN,
+    DESIGN
+}

--- a/src/main/java/com/umc/site/domain/part/repository/PartRepository.java
+++ b/src/main/java/com/umc/site/domain/part/repository/PartRepository.java
@@ -1,0 +1,15 @@
+package com.umc.site.domain.part.repository;
+
+import com.umc.site.domain.part.entity.Part;
+import com.umc.site.domain.part.entity.enums.PartType;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface PartRepository extends JpaRepository<Part, Long> {
+
+    Part findByPartType(PartType partType);
+
+    List<Part> findAllByIsRecruiting(Boolean isRecruiting);
+
+}

--- a/src/main/java/com/umc/site/domain/part/service/PartQueryService.java
+++ b/src/main/java/com/umc/site/domain/part/service/PartQueryService.java
@@ -1,0 +1,10 @@
+package com.umc.site.domain.part.service;
+
+import com.umc.site.domain.part.dto.PartResponseDTO;
+
+import java.util.List;
+
+public interface PartQueryService {
+
+    List<PartResponseDTO.RecruitingPartDTO> getRecruitingPartList();
+}

--- a/src/main/java/com/umc/site/domain/part/service/PartQueryServiceImpl.java
+++ b/src/main/java/com/umc/site/domain/part/service/PartQueryServiceImpl.java
@@ -1,0 +1,29 @@
+package com.umc.site.domain.part.service;
+
+import com.umc.site.domain.part.converter.PartConverter;
+import com.umc.site.domain.part.dto.PartResponseDTO;
+import com.umc.site.domain.part.entity.Part;
+import com.umc.site.domain.part.repository.PartRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class PartQueryServiceImpl implements PartQueryService {
+
+    private final PartRepository partRepository;
+
+    @Override
+    public List<PartResponseDTO.RecruitingPartDTO> getRecruitingPartList() {
+
+        List<Part> parts = partRepository.findAllByIsRecruiting(true);
+
+        return parts.stream()
+                .map(PartConverter::toRecruitingPartDTO)
+                .toList();
+    }
+}

--- a/src/main/java/com/umc/site/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/umc/site/global/apiPayload/code/status/ErrorStatus.java
@@ -14,6 +14,9 @@ public enum ErrorStatus implements BaseErrorCode {
     _BAD_REQUEST(HttpStatus.BAD_REQUEST,"COMMON400","잘못된 요청입니다."),
     _UNAUTHORIZED(HttpStatus.UNAUTHORIZED,"COMMON401","인증이 필요합니다."),
     _FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON403", "금지된 요청입니다."),
+
+    // 파트 관련 에러
+    PART_NOT_RECRUITNIG(HttpStatus.BAD_REQUEST, "PART4001", "모집 대상이 아닌 파트입니다."),
     
     // 기수 관련 에러
     COHORT_NOT_FOUND(HttpStatus.NOT_FOUND, "COHORT4001", "존재하지 않는 기수입니다."),

--- a/src/main/java/com/umc/site/global/apiPayload/exception/handler/PartHandler.java
+++ b/src/main/java/com/umc/site/global/apiPayload/exception/handler/PartHandler.java
@@ -1,0 +1,10 @@
+package com.umc.site.global.apiPayload.exception.handler;
+
+import com.umc.site.global.apiPayload.code.BaseErrorCode;
+import com.umc.site.global.apiPayload.exception.GeneralException;
+
+public class PartHandler extends GeneralException {
+    public PartHandler(BaseErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/umc/site/global/validation/annotation/ValidPart.java
+++ b/src/main/java/com/umc/site/global/validation/annotation/ValidPart.java
@@ -1,0 +1,18 @@
+package com.umc.site.global.validation.annotation;
+
+import com.umc.site.global.validation.validator.PartValidator;
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.*;
+
+@Documented
+@Constraint(validatedBy = PartValidator.class)
+@Target( { ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ValidPart {
+
+    String message() default "모집하지 않는 파트입니다.";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/com/umc/site/global/validation/validator/PartValidator.java
+++ b/src/main/java/com/umc/site/global/validation/validator/PartValidator.java
@@ -1,0 +1,36 @@
+package com.umc.site.global.validation.validator;
+
+import com.umc.site.domain.part.entity.enums.PartType;
+import com.umc.site.domain.part.repository.PartRepository;
+import com.umc.site.global.apiPayload.code.status.ErrorStatus;
+import com.umc.site.global.validation.annotation.ValidPart;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class PartValidator implements ConstraintValidator<ValidPart, PartType> {
+
+    private final PartRepository partRepository;
+
+
+    @Override
+    public void initialize(ValidPart constraintAnnotation) {
+        ConstraintValidator.super.initialize(constraintAnnotation);
+    }
+
+    @Override
+    public boolean isValid(PartType partType, ConstraintValidatorContext context) {
+
+        boolean isValid = partRepository.findByPartType(partType).getIsRecruiting();
+
+        if(!isValid) {
+            context.disableDefaultConstraintViolation();
+            context.buildConstraintViolationWithTemplate(ErrorStatus.PART_NOT_RECRUITNIG.toString()).addConstraintViolation();
+        }
+
+        return isValid;
+    }
+}


### PR DESCRIPTION
## 🛰️ Issue Number
- resolve #38

## 📝 작업 내용
-   커리큘럼 페이지에서 모집 중인 파트를 조회하는 API를 구현했습니다
-  커리큘럼 페이지에서 각 파트에 해당하는 커리큘럼을 조회하는 API를 구현했습니다.

## 💬 리뷰 요구사항
> 희선띠와 얘기한 결과, 각 파트별 소개 부분은 프론트에서 처리하기로 했습니다!

> 커리큘럼을 조회할 때, 모집 중인 파트인지 검증하는 @ValidPart 어노테이션을 구현했는데, 적용이 안 돼서 서비스 단에서 핸들러로 처리하게 했습니다. 혹시 이유를 아신다면 조언 부탁드립니다 🥺
