### PR TITLE
Feat: 운영진 수정 API 구현

### DIFF
--- a/src/main/java/com/umc/site/domain/club_admin/controller/ClubAdminController.java
+++ b/src/main/java/com/umc/site/domain/club_admin/controller/ClubAdminController.java
@@ -43,15 +43,14 @@ public class ClubAdminController {
 
     // 운영진 수정
     @Operation(summary = "운영진 수정", description = "운영진을 수정합니다.")
-    @Parameters ({
+    @Parameters({
             @Parameter(name = "clubAdminId", description = "운영진의 ID, path variable 입니다.")
     })
     @PatchMapping(value = "/club-admins/{clubAdminId}", consumes = {MediaType.MULTIPART_FORM_DATA_VALUE})
     public ApiResponse<ClubAdminResponseDTO.UpdateClubAdminResultDTO> updateClubAdmin(@PathVariable Long clubAdminId,
                                                                                       @RequestPart("request") @Valid ClubAdminRequestDTO.UpdateClubAdminDTO request,
-                                                                                      @RequestPart("file") MultipartFile file) {
+                                                                                      @RequestPart(value = "file", required = false) MultipartFile file) {
 
         return ApiResponse.onSuccess(clubAdminCommandService.updateClubAdmin(clubAdminId, request, file));
     }
-
 }

--- a/src/main/java/com/umc/site/domain/club_admin/controller/ClubAdminController.java
+++ b/src/main/java/com/umc/site/domain/club_admin/controller/ClubAdminController.java
@@ -6,6 +6,8 @@ import com.umc.site.domain.club_admin.service.ClubAdminCommandService;
 import com.umc.site.domain.club_admin.service.ClubAdminQueryService;
 import com.umc.site.global.apiPayload.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
@@ -32,10 +34,24 @@ public class ClubAdminController {
 
     // 운영진 생성
     @Operation(summary = "운영진 생성", description = "운영진을 생성합니다.")
-    @PostMapping(value = "club-admins", consumes = {MediaType.MULTIPART_FORM_DATA_VALUE})
+    @PostMapping(value = "/club-admins", consumes = {MediaType.MULTIPART_FORM_DATA_VALUE})
     public ApiResponse<ClubAdminResponseDTO.CreateClubAdminResultDTO> createClubAdmin(@RequestPart("request") @Valid ClubAdminRequestDTO.CreateClubAdminDTO request,
                                                                                       @RequestPart("file") MultipartFile file) {
 
         return ApiResponse.onSuccess(clubAdminCommandService.createClubAdmin(request, file));
     }
+
+    // 운영진 수정
+    @Operation(summary = "운영진 수정", description = "운영진을 수정합니다.")
+    @Parameters ({
+            @Parameter(name = "clubAdminId", description = "운영진의 ID, path variable 입니다.")
+    })
+    @PatchMapping(value = "/club-admins/{clubAdminId}", consumes = {MediaType.MULTIPART_FORM_DATA_VALUE})
+    public ApiResponse<ClubAdminResponseDTO.UpdateClubAdminResultDTO> updateClubAdmin(@PathVariable Long clubAdminId,
+                                                                                      @RequestPart("request") @Valid ClubAdminRequestDTO.UpdateClubAdminDTO request,
+                                                                                      @RequestPart("file") MultipartFile file) {
+
+        return ApiResponse.onSuccess(clubAdminCommandService.updateClubAdmin(clubAdminId, request, file));
+    }
+
 }

--- a/src/main/java/com/umc/site/domain/club_admin/converter/ClubAdminConverter.java
+++ b/src/main/java/com/umc/site/domain/club_admin/converter/ClubAdminConverter.java
@@ -29,7 +29,7 @@ public class ClubAdminConverter {
                 .build();
     }
 
-    // 운영진 생성
+
     public static ClubAdmin toClubAdmin(ClubAdminRequestDTO.CreateClubAdminDTO request) {
 
         return ClubAdmin.builder()
@@ -40,10 +40,29 @@ public class ClubAdminConverter {
                 .build();
     }
 
+    // 운영진 생성
     public static ClubAdminResponseDTO.CreateClubAdminResultDTO toCreateClubAdminResultDTO(ClubAdmin clubAdmin) {
         return ClubAdminResponseDTO.CreateClubAdminResultDTO.builder()
                 .clubAdminId(clubAdmin.getId())
                 .createdAt(clubAdmin.getCreatedAt())
+                .build();
+    }
+
+    // 운영진 수정
+    public static ClubAdminResponseDTO.UpdateClubAdminResultDTO toUpdateClubAdminResultDTO(ClubAdmin clubAdmin, Image image,
+                                                                                           List<RoleHistory> roleHistories) {
+
+        return ClubAdminResponseDTO.UpdateClubAdminResultDTO.builder()
+                .clubAdminId(clubAdmin.getId())
+                .role(clubAdmin.getRole())
+                .name(clubAdmin.getName())
+                .nickname(clubAdmin.getNickname())
+                .commitment(clubAdmin.getCommitment())
+                .image(ImageConverter.toImageDTO(image))
+                .roleHistories(roleHistories.stream()
+                        .map(RoleHistoryConverter::toRoleHistoryDTO)
+                        .toList())
+                .updatedAt(clubAdmin.getUpdatedAt())
                 .build();
     }
 }

--- a/src/main/java/com/umc/site/domain/club_admin/dto/ClubAdminRequestDTO.java
+++ b/src/main/java/com/umc/site/domain/club_admin/dto/ClubAdminRequestDTO.java
@@ -38,4 +38,25 @@ public class ClubAdminRequestDTO {
         @Size(min = 1)
         private List<RoleHistoryRequestDTO.CreateRoleHistoryDTO> roleHistoryList;
     }
+
+    @Getter
+    public static class UpdateClubAdminDTO {
+
+        // 이름
+        private String name;
+
+        // 닉네임
+        private String nickname;
+
+        // 한 줄 다짐
+        private String commitment;
+
+        // 역할
+        private Role role;
+
+        // 활동 이력
+        private List<RoleHistoryRequestDTO.UpdateRoleHistoryDTO> roleHistories;
+    }
+
+
 }

--- a/src/main/java/com/umc/site/domain/club_admin/dto/ClubAdminResponseDTO.java
+++ b/src/main/java/com/umc/site/domain/club_admin/dto/ClubAdminResponseDTO.java
@@ -37,4 +37,20 @@ public class ClubAdminResponseDTO {
         private Long clubAdminId;
         LocalDateTime createdAt;
     }
+
+    // 운영진 수정 응답
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class UpdateClubAdminResultDTO {
+        Long clubAdminId;
+        String name;
+        String nickname;
+        String commitment;
+        Role role;
+        ImageResponseDTO.ImageDTO image;
+        List<RoleHistoryResponseDTO.RoleHistoryDTO> roleHistories;
+        LocalDateTime updatedAt;
+    }
 }

--- a/src/main/java/com/umc/site/domain/club_admin/entity/ClubAdmin.java
+++ b/src/main/java/com/umc/site/domain/club_admin/entity/ClubAdmin.java
@@ -5,11 +5,15 @@ import com.umc.site.domain.role_history.entity.RoleHistory;
 import com.umc.site.global.common.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.DynamicInsert;
+import org.hibernate.annotations.DynamicUpdate;
 
 import java.util.ArrayList;
 import java.util.List;
 
 @Entity
+@DynamicInsert
+@DynamicUpdate
 @Builder
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -20,19 +24,24 @@ public class ClubAdmin extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Setter
     @Column(nullable = false, length = 10)
     private String name;
 
+    @Setter
     @Column(nullable = false, length = 10)
     private String nickname;
 
+    @Setter
     @Column(nullable = false, length = 50)
     private String commitment;
 
+    @Setter
     @Enumerated(EnumType.STRING)
     @Column(columnDefinition = "VARCHAR(30)")
     private Role role;
 
+    @Setter
     @OneToMany(cascade = CascadeType.ALL, mappedBy = "clubAdmin")
     private List<RoleHistory> roleHistories = new ArrayList<>();
 }

--- a/src/main/java/com/umc/site/domain/club_admin/service/ClubAdminCommandService.java
+++ b/src/main/java/com/umc/site/domain/club_admin/service/ClubAdminCommandService.java
@@ -8,4 +8,7 @@ public interface ClubAdminCommandService {
 
     // 운영진 생성
     ClubAdminResponseDTO.CreateClubAdminResultDTO createClubAdmin(ClubAdminRequestDTO.CreateClubAdminDTO request, MultipartFile file);
+
+    // 운영진 수정
+    ClubAdminResponseDTO.UpdateClubAdminResultDTO updateClubAdmin(Long clubAdminId, ClubAdminRequestDTO.UpdateClubAdminDTO request, MultipartFile file);
 }

--- a/src/main/java/com/umc/site/domain/club_admin/service/ClubAdminCommandServiceImpl.java
+++ b/src/main/java/com/umc/site/domain/club_admin/service/ClubAdminCommandServiceImpl.java
@@ -74,15 +74,19 @@ public class ClubAdminCommandServiceImpl implements ClubAdminCommandService{
             clubAdmin.setCommitment(request.getCommitment());
         }
         if (request.getRole() != null) {
-            clubAdmin.setCommitment(request.getCommitment());
+            clubAdmin.setRole(request.getRole());
         }
 
-        updateClubAdminImage(clubAdmin, file);
+        if (file != null && !file.isEmpty()) {
+            updateClubAdminImage(clubAdmin, file);
+        }
         updateClubAdminRoleHistory(request);
 
         ClubAdmin updatedClubAdmin = clubAdminRepository.save(clubAdmin);
 
-        Image image = imageRepository.findByClubAdmin(updatedClubAdmin).get();
+        Image image = imageRepository.findByClubAdmin(updatedClubAdmin)
+                .orElseThrow(() -> new ImageHandler(ErrorStatus.IMAGE_NOT_FOUND));
+
         List<RoleHistory> roleHistories = roleHistoryRepository.findAllByClubAdmin(updatedClubAdmin);
 
         return ClubAdminConverter.toUpdateClubAdminResultDTO(updatedClubAdmin, image, roleHistories);
@@ -112,7 +116,7 @@ public class ClubAdminCommandServiceImpl implements ClubAdminCommandService{
                     .orElseThrow(() -> new ImageHandler(ErrorStatus.IMAGE_NOT_FOUND));
 
             // S3에서 기존 운영진 사진 삭제
-            s3Manager.deleteFile(existingImage.getUuid());
+            s3Manager.deleteFile(existingImage.getFileName());
 
             // DB에서 기존 운영진 사진 삭제
             imageRepository.delete(existingImage);

--- a/src/main/java/com/umc/site/domain/club_admin/service/ClubAdminCommandServiceImpl.java
+++ b/src/main/java/com/umc/site/domain/club_admin/service/ClubAdminCommandServiceImpl.java
@@ -5,10 +5,18 @@ import com.umc.site.domain.club_admin.dto.ClubAdminRequestDTO;
 import com.umc.site.domain.club_admin.dto.ClubAdminResponseDTO;
 import com.umc.site.domain.club_admin.entity.ClubAdmin;
 import com.umc.site.domain.club_admin.repository.ClubAdminRepository;
+import com.umc.site.domain.image.entity.Image;
+import com.umc.site.domain.image.repository.ImageRepository;
 import com.umc.site.domain.image.service.ImageCommandService;
 import com.umc.site.domain.role_history.converter.RoleHistoryConverter;
+import com.umc.site.domain.role_history.dto.RoleHistoryRequestDTO;
 import com.umc.site.domain.role_history.entity.RoleHistory;
 import com.umc.site.domain.role_history.repository.RoleHistoryRepository;
+import com.umc.site.global.apiPayload.code.status.ErrorStatus;
+import com.umc.site.global.apiPayload.exception.handler.ClubAdminHandler;
+import com.umc.site.global.apiPayload.exception.handler.ImageHandler;
+import com.umc.site.global.apiPayload.exception.handler.RoleHistoryHandler;
+import com.umc.site.global.manager.AmazonS3Manager;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -22,7 +30,9 @@ public class ClubAdminCommandServiceImpl implements ClubAdminCommandService{
 
     private final ClubAdminRepository clubAdminRepository;
     private final RoleHistoryRepository roleHistoryRepository;
+    private final ImageRepository imageRepository;
     private final ImageCommandService imageCommandService;
+    private final AmazonS3Manager s3Manager;
 
     // 운영진 생성
     @Override
@@ -42,5 +52,74 @@ public class ClubAdminCommandServiceImpl implements ClubAdminCommandService{
         imageCommandService.createClubAdminImage(file, savedClubAdmin);
 
         return ClubAdminConverter.toCreateClubAdminResultDTO(savedClubAdmin);
+    }
+
+    // 운영진 수정
+    @Override
+    @Transactional
+    public ClubAdminResponseDTO.UpdateClubAdminResultDTO updateClubAdmin(Long clubAdminId, ClubAdminRequestDTO.UpdateClubAdminDTO request, MultipartFile file) {
+
+        // clubAdminId로 운영진 조회
+        ClubAdmin clubAdmin = clubAdminRepository.findById(clubAdminId)
+                .orElseThrow(() -> new ClubAdminHandler(ErrorStatus.CLUB_ADMIN_NOT_FOUND));
+
+        // 운영진 정보 업데이트
+        if (request.getName() != null) {
+            clubAdmin.setName(request.getName());
+        }
+        if (request.getNickname() != null) {
+            clubAdmin.setNickname(request.getNickname());
+        }
+        if (request.getCommitment() != null) {
+            clubAdmin.setCommitment(request.getCommitment());
+        }
+        if (request.getRole() != null) {
+            clubAdmin.setCommitment(request.getCommitment());
+        }
+
+        updateClubAdminImage(clubAdmin, file);
+        updateClubAdminRoleHistory(request);
+
+        ClubAdmin updatedClubAdmin = clubAdminRepository.save(clubAdmin);
+
+        Image image = imageRepository.findByClubAdmin(updatedClubAdmin).get();
+        List<RoleHistory> roleHistories = roleHistoryRepository.findAllByClubAdmin(updatedClubAdmin);
+
+        return ClubAdminConverter.toUpdateClubAdminResultDTO(updatedClubAdmin, image, roleHistories);
+    }
+
+    // 운영진 활동 이력 업데이트
+    private void updateClubAdminRoleHistory(ClubAdminRequestDTO.UpdateClubAdminDTO request) {
+
+        if (request.getRoleHistories() != null && !request.getRoleHistories().isEmpty()) {
+
+            for (RoleHistoryRequestDTO.UpdateRoleHistoryDTO roleHistoryDTO : request.getRoleHistories()) {
+                RoleHistory roleHistory = roleHistoryRepository.findById(roleHistoryDTO.getRoleHistoryId())
+                        .orElseThrow(() -> new RoleHistoryHandler(ErrorStatus.ROLE_HISTORY_NOT_FOUND));
+
+                roleHistory.setContent(roleHistoryDTO.getContent());
+
+                roleHistoryRepository.save(roleHistory);
+            }
+        }
+    }
+
+    // 운영진 사진 업데이트
+    private void updateClubAdminImage(ClubAdmin clubAdmin, MultipartFile file) {
+
+        if (file != null && !file.isEmpty()) {
+            Image existingImage = imageRepository.findByClubAdmin(clubAdmin)
+                    .orElseThrow(() -> new ImageHandler(ErrorStatus.IMAGE_NOT_FOUND));
+
+            // S3에서 기존 운영진 사진 삭제
+            s3Manager.deleteFile(existingImage.getUuid());
+
+            // DB에서 기존 운영진 사진 삭제
+            imageRepository.delete(existingImage);
+            imageRepository.flush();
+
+            // DB에 새로 생성
+            imageCommandService.createClubAdminImage(file, clubAdmin);
+        }
     }
 }

--- a/src/main/java/com/umc/site/domain/club_admin/service/ClubAdminCommandServiceImpl.java
+++ b/src/main/java/com/umc/site/domain/club_admin/service/ClubAdminCommandServiceImpl.java
@@ -112,15 +112,8 @@ public class ClubAdminCommandServiceImpl implements ClubAdminCommandService{
     private void updateClubAdminImage(ClubAdmin clubAdmin, MultipartFile file) {
 
         if (file != null && !file.isEmpty()) {
-            Image existingImage = imageRepository.findByClubAdmin(clubAdmin)
-                    .orElseThrow(() -> new ImageHandler(ErrorStatus.IMAGE_NOT_FOUND));
-
-            // S3에서 기존 운영진 사진 삭제
-            s3Manager.deleteFile(existingImage.getFileName());
-
-            // DB에서 기존 운영진 사진 삭제
-            imageRepository.delete(existingImage);
-            imageRepository.flush();
+            // 이미지 삭제
+            imageCommandService.deleteClubAdminImage(clubAdmin);
 
             // DB에 새로 생성
             imageCommandService.createClubAdminImage(file, clubAdmin);

--- a/src/main/java/com/umc/site/domain/club_admin/service/ClubAdminQueryServiceImpl.java
+++ b/src/main/java/com/umc/site/domain/club_admin/service/ClubAdminQueryServiceImpl.java
@@ -8,11 +8,14 @@ import com.umc.site.domain.image.entity.Image;
 import com.umc.site.domain.image.repository.ImageRepository;
 import com.umc.site.domain.role_history.entity.RoleHistory;
 import com.umc.site.domain.role_history.repository.RoleHistoryRepository;
+import com.umc.site.global.apiPayload.code.status.ErrorStatus;
+import com.umc.site.global.apiPayload.exception.handler.ImageHandler;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Service
@@ -44,7 +47,9 @@ public class ClubAdminQueryServiceImpl implements ClubAdminQueryService{
                         case IOS_LEADER -> "IOS 파트장";
                     };
 
-                    Image image = imageRepository.findByClubAdmin(clubAdmin);
+                    Image image = imageRepository.findByClubAdmin(clubAdmin)
+                            .orElseThrow(() -> new ImageHandler(ErrorStatus.IMAGE_NOT_FOUND));
+
                     List<RoleHistory> roleHistories = roleHistoryRepository.findAllByClubAdmin(clubAdmin);
 
                     return ClubAdminConverter.toClubAdminInfoDTO(clubAdmin, image, roleHistories, role);

--- a/src/main/java/com/umc/site/domain/image/entity/Image.java
+++ b/src/main/java/com/umc/site/domain/image/entity/Image.java
@@ -5,9 +5,13 @@ import com.umc.site.domain.project.entity.Project;
 import com.umc.site.global.common.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.DynamicInsert;
+import org.hibernate.annotations.DynamicUpdate;
 
 @Entity
 @Getter
+@DynamicInsert
+@DynamicUpdate
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
@@ -17,12 +21,15 @@ public class Image extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Setter
     @Column(nullable = false, length = 100, unique = true)
     private String uuid;
 
+    @Setter
     @Column(nullable = false, length = 100)
     private String fileName;
 
+    @Setter
     @Column(nullable = false, length = 300)
     private String fileUrl;
 

--- a/src/main/java/com/umc/site/domain/image/entity/Image.java
+++ b/src/main/java/com/umc/site/domain/image/entity/Image.java
@@ -34,7 +34,8 @@ public class Image extends BaseEntity {
     private String fileUrl;
 
     @Setter
-    @OneToOne(cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+//    @OneToOne(cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "club_admin_id", referencedColumnName = "id")
     private ClubAdmin clubAdmin;
 

--- a/src/main/java/com/umc/site/domain/image/repository/ImageRepository.java
+++ b/src/main/java/com/umc/site/domain/image/repository/ImageRepository.java
@@ -3,11 +3,14 @@ package com.umc.site.domain.image.repository;
 import com.umc.site.domain.club_admin.entity.ClubAdmin;
 import com.umc.site.domain.image.entity.Image;
 import com.umc.site.domain.project.entity.Project;
+import io.swagger.v3.oas.annotations.Operation;
 import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
 
 public interface ImageRepository extends JpaRepository<Image, Long> {
 
-    Image findByClubAdmin(ClubAdmin clubAdmin);
+    Optional<Image> findByClubAdmin(ClubAdmin clubAdmin);
 
     Image findByProject(Project project);
 

--- a/src/main/java/com/umc/site/domain/image/service/ImageCommandService.java
+++ b/src/main/java/com/umc/site/domain/image/service/ImageCommandService.java
@@ -14,4 +14,7 @@ public interface ImageCommandService {
 
     // 운영진 사진 생성
     void createClubAdminImage(MultipartFile file, ClubAdmin clubAdmin);
+
+    // 운영진 사진 삭제
+    void deleteClubAdminImage(ClubAdmin clubAdmin);
 }

--- a/src/main/java/com/umc/site/domain/image/service/ImageCommandServiceImpl.java
+++ b/src/main/java/com/umc/site/domain/image/service/ImageCommandServiceImpl.java
@@ -48,7 +48,7 @@ public class ImageCommandServiceImpl implements ImageCommandService {
     // 운영진 사진 생성
     @Override
     @Transactional
-    public void createClubAdminImage(MultipartFile file, ClubAdmin clubAdmin){
+    public void createClubAdminImage(MultipartFile file, ClubAdmin clubAdmin) {
 
         String keyName = s3Manager.generateProjectKeyName();
         String fileUrl = s3Manager.uploadFile(keyName, file);
@@ -58,4 +58,16 @@ public class ImageCommandServiceImpl implements ImageCommandService {
 
         imageRepository.save(image);
     }
+
+    // 운영진 사진 수정
+//    @Override
+//    @Transactional
+//    public void updateClubAdminImage(MultipartFile file, ClubAdmin clubAdmin, Image image) {
+//
+//        String keyName = s3Manager.generateProjectKeyName();
+//        String fileUrl = s3Manager.uploadFile(keyName, file);
+//
+//        Image
+//
+//    }
 }

--- a/src/main/java/com/umc/site/domain/image/service/ImageCommandServiceImpl.java
+++ b/src/main/java/com/umc/site/domain/image/service/ImageCommandServiceImpl.java
@@ -5,6 +5,8 @@ import com.umc.site.domain.image.converter.ImageConverter;
 import com.umc.site.domain.image.entity.Image;
 import com.umc.site.domain.image.repository.ImageRepository;
 import com.umc.site.domain.project.entity.Project;
+import com.umc.site.global.apiPayload.code.status.ErrorStatus;
+import com.umc.site.global.apiPayload.exception.handler.ImageHandler;
 import com.umc.site.global.manager.AmazonS3Manager;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -57,5 +59,22 @@ public class ImageCommandServiceImpl implements ImageCommandService {
         image.setClubAdmin(clubAdmin);
 
         imageRepository.save(image);
+    }
+
+    // 운영진 사진 삭제
+    // 프로젝트 사진 삭제
+    @Override
+    @Transactional
+    public void deleteClubAdminImage(ClubAdmin clubAdmin) {
+
+        Image existingImage = imageRepository.findByClubAdmin(clubAdmin)
+                .orElseThrow(() -> new ImageHandler(ErrorStatus.IMAGE_NOT_FOUND));
+
+        // S3에서 기존 운영진 사진 삭제
+        s3Manager.deleteFile(existingImage.getFileName());
+
+        // DB에서 기존 운영진 사진 삭제
+        imageRepository.delete(existingImage);
+        imageRepository.flush();
     }
 }

--- a/src/main/java/com/umc/site/domain/image/service/ImageCommandServiceImpl.java
+++ b/src/main/java/com/umc/site/domain/image/service/ImageCommandServiceImpl.java
@@ -58,16 +58,4 @@ public class ImageCommandServiceImpl implements ImageCommandService {
 
         imageRepository.save(image);
     }
-
-    // 운영진 사진 수정
-//    @Override
-//    @Transactional
-//    public void updateClubAdminImage(MultipartFile file, ClubAdmin clubAdmin, Image image) {
-//
-//        String keyName = s3Manager.generateProjectKeyName();
-//        String fileUrl = s3Manager.uploadFile(keyName, file);
-//
-//        Image
-//
-//    }
 }

--- a/src/main/java/com/umc/site/domain/image/service/ImageCommandServiceImpl.java
+++ b/src/main/java/com/umc/site/domain/image/service/ImageCommandServiceImpl.java
@@ -50,7 +50,7 @@ public class ImageCommandServiceImpl implements ImageCommandService {
     @Transactional
     public void createClubAdminImage(MultipartFile file, ClubAdmin clubAdmin) {
 
-        String keyName = s3Manager.generateProjectKeyName();
+        String keyName = s3Manager.generateClubAdminKeyName();
         String fileUrl = s3Manager.uploadFile(keyName, file);
 
         Image image = ImageConverter.toImage(keyName, fileUrl);

--- a/src/main/java/com/umc/site/domain/role_history/dto/RoleHistoryRequestDTO.java
+++ b/src/main/java/com/umc/site/domain/role_history/dto/RoleHistoryRequestDTO.java
@@ -12,4 +12,13 @@ public class RoleHistoryRequestDTO {
         @NotBlank
         private String content;
     }
+
+    // 활동 이력 수정
+    @Getter
+    public static class UpdateRoleHistoryDTO {
+
+        private Long roleHistoryId;
+
+        private String content;
+    }
 }

--- a/src/main/java/com/umc/site/domain/role_history/entity/RoleHistory.java
+++ b/src/main/java/com/umc/site/domain/role_history/entity/RoleHistory.java
@@ -16,6 +16,7 @@ public class RoleHistory extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Setter
     @Column(nullable = false, length = 100)
     private String content;
 

--- a/src/main/java/com/umc/site/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/umc/site/global/apiPayload/code/status/ErrorStatus.java
@@ -14,6 +14,15 @@ public enum ErrorStatus implements BaseErrorCode {
     _BAD_REQUEST(HttpStatus.BAD_REQUEST,"COMMON400","잘못된 요청입니다."),
     _UNAUTHORIZED(HttpStatus.UNAUTHORIZED,"COMMON401","인증이 필요합니다."),
     _FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON403", "금지된 요청입니다."),
+
+    // 이미지 관련 에러
+    IMAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "IMAGE_NOT4001", "존재하지 않는 운영진 이미지입니다."),
+
+    // 운영진 관련 에러
+    CLUB_ADMIN_NOT_FOUND(HttpStatus.NOT_FOUND, "CLUB_ADMIN4001", "존재하지 않는 운영진입니다."),
+
+    // 활동 이력 관련 에러
+    ROLE_HISTORY_NOT_FOUND(HttpStatus.NOT_FOUND, "ROLE_HISTORY4001", "존재하지 않는 활동 이력입니다."),
     
     // 기수 관련 에러
     COHORT_NOT_FOUND(HttpStatus.NOT_FOUND, "COHORT4001", "존재하지 않는 기수입니다."),

--- a/src/main/java/com/umc/site/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/umc/site/global/apiPayload/code/status/ErrorStatus.java
@@ -15,6 +15,9 @@ public enum ErrorStatus implements BaseErrorCode {
     _UNAUTHORIZED(HttpStatus.UNAUTHORIZED,"COMMON401","인증이 필요합니다."),
     _FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON403", "금지된 요청입니다."),
 
+
+    // 파트 관련 에러
+    PART_NOT_RECRUITNIG(HttpStatus.BAD_REQUEST, "PART4001", "모집 대상이 아닌 파트입니다."),
     // 이미지 관련 에러
     IMAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "IMAGE_NOT4001", "존재하지 않는 운영진 이미지입니다."),
 
@@ -23,7 +26,7 @@ public enum ErrorStatus implements BaseErrorCode {
 
     // 활동 이력 관련 에러
     ROLE_HISTORY_NOT_FOUND(HttpStatus.NOT_FOUND, "ROLE_HISTORY4001", "존재하지 않는 활동 이력입니다."),
-    
+
     // 기수 관련 에러
     COHORT_NOT_FOUND(HttpStatus.NOT_FOUND, "COHORT4001", "존재하지 않는 기수입니다."),
 

--- a/src/main/java/com/umc/site/global/apiPayload/exception/handler/ClubAdminHandler.java
+++ b/src/main/java/com/umc/site/global/apiPayload/exception/handler/ClubAdminHandler.java
@@ -1,0 +1,10 @@
+package com.umc.site.global.apiPayload.exception.handler;
+
+import com.umc.site.global.apiPayload.code.BaseErrorCode;
+import com.umc.site.global.apiPayload.exception.GeneralException;
+
+public class ClubAdminHandler extends GeneralException {
+    public ClubAdminHandler(BaseErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/umc/site/global/apiPayload/exception/handler/ImageHandler.java
+++ b/src/main/java/com/umc/site/global/apiPayload/exception/handler/ImageHandler.java
@@ -1,0 +1,10 @@
+package com.umc.site.global.apiPayload.exception.handler;
+
+import com.umc.site.global.apiPayload.code.BaseErrorCode;
+import com.umc.site.global.apiPayload.exception.GeneralException;
+
+public class ImageHandler extends GeneralException {
+    public ImageHandler(BaseErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/umc/site/global/apiPayload/exception/handler/RoleHistoryHandler.java
+++ b/src/main/java/com/umc/site/global/apiPayload/exception/handler/RoleHistoryHandler.java
@@ -1,0 +1,11 @@
+package com.umc.site.global.apiPayload.exception.handler;
+
+import com.umc.site.global.apiPayload.code.BaseErrorCode;
+import com.umc.site.global.apiPayload.exception.GeneralException;
+
+public class RoleHistoryHandler extends GeneralException {
+    public RoleHistoryHandler(BaseErrorCode errorCode) {
+        super(errorCode);
+    }
+
+}


### PR DESCRIPTION
## 🛰️ Issue Number
- resolve #33

## 📝 작업 내용
-   운영진 수정 api 구현했습니다. (운영진 정보, 운영진 사진, 운영진 활동 이력)
- 저는 뭔가 수정하고 싶지 않은 값은 안 넣는 방향으로 해보고 싶어서...!! 그렇게 해봤어요 헷
- 만약 추후에 어드민 페이지가 생긴다면 기존 값들도 보여줄 수 있도록 리팩토링 할 예정입니다!!
- 이미지 엔티티같은 경우에는... cascade 옵션을 유지하고 싶었지만 그걸 추가하는 순간 에러가 생겨서... 저도 해결하지 못 했슴니다 ^_ㅠ

## 💬 리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
커밋 기록 망했어요 브랜치 이리저리 이동하고 그러다가...
엉망진창... 한 번만 봐주세요 🥲